### PR TITLE
fix bug in parsing of paired FASTA files

### DIFF
--- a/source/ReadAlignChunk_processChunks.cpp
+++ b/source/ReadAlignChunk_processChunks.cpp
@@ -82,7 +82,7 @@ void ReadAlignChunk::processChunks() {//read-map-write chunks
 //                         P->inOut->readIn[imate].getline(chunkIn[imate] + chunkInSizeBytesTotal[imate], DEF_readNameSeqLengthMax+1 );                            
 //                         };                        
                         nextChar=P->inOut->readIn[imate].peek();                        
-                        while (nextChar!='@' && nextChar!='>' && nextChar!=' ' && nextChar!='\n' && P->inOut->readIn[0].good()) {//read multi-line fasta
+                        while (nextChar!='@' && nextChar!='>' && nextChar!=' ' && nextChar!='\n' && P->inOut->readIn[imate].good()) {//read multi-line fasta
                             P->inOut->readIn[imate].getline(chunkIn[imate] + chunkInSizeBytesTotal[imate], DEF_readSeqLengthMax + 1 );
                             if (P->inOut->readIn[imate].gcount()<2) break; //no more input
                             chunkInSizeBytesTotal[imate] += P->inOut->readIn[imate].gcount()-1;   


### PR DESCRIPTION
call to .good() was always on the first read file, which meant that the
last line of the second (aka right reads) FASTA file wasn't being read,
so reading pairs of FASTA files would fail at the end.  Fix is to call
.good() on the P->inOut->readIn[imate] instead.
