### PR TITLE
include GlobalVariables.h instead of .cpp

### DIFF
--- a/source/STAR.cpp
+++ b/source/STAR.cpp
@@ -8,7 +8,7 @@
 #include "genomeGenerate.h"
 #include "outputSJ.h"
 #include "ThreadControl.h"
-#include "GlobalVariables.cpp"
+#include "GlobalVariables.h"
 #include "TimeFunctions.h"
 #include <sys/types.h>
 #include <sys/stat.h>


### PR DESCRIPTION
It seems to compile either way? Most of the files here include GlobalVariables.h, so I think this may have been a typo.