### PR TITLE
Use header instead of extern for bam_cat

### DIFF
--- a/source/STAR.cpp
+++ b/source/STAR.cpp
@@ -19,13 +19,11 @@
 #include "BAMbinSortByCoordinate.h"
 #include "BAMbinSortUnmapped.h"
 #include "signalFromBAM.h"
-// #include "sjdbBuildIndex.h"
 #include "mapThreadsSpawn.h"
 #include "ErrorWarning.h"
-// #include "sjdbLoadFromStream.h"
-// #include "sjdbPrepare.h"
 #include "SjdbClass.h"
 #include "sjdbInsertJunctions.h"
+#include "bam_cat.c"
 
 
 #include "htslib/htslib/sam.h"

--- a/source/STAR.cpp
+++ b/source/STAR.cpp
@@ -1,3 +1,6 @@
+#include <sys/types.h>
+#include <sys/stat.h>
+
 #include "IncludeDefine.h"
 #include "Parameters.h"
 #include "SequenceFuns.h"
@@ -10,8 +13,6 @@
 #include "ThreadControl.h"
 #include "GlobalVariables.cpp"
 #include "TimeFunctions.h"
-#include <sys/types.h>
-#include <sys/stat.h>
 #include "ErrorWarning.h"
 #include "sysRemoveDir.h"
 #include "BAMfunctions.h"
@@ -23,11 +24,9 @@
 #include "ErrorWarning.h"
 #include "SjdbClass.h"
 #include "sjdbInsertJunctions.h"
-#include "bam_cat.c"
-
+#include "bam_cat.h"
 
 #include "htslib/htslib/sam.h"
-extern int bam_cat(int nfn, char * const *fn, const bam_hdr_t *h, const char* outbam);
 
 int main(int argInN, char* argIn[]) {
    

--- a/source/bam_cat.c
+++ b/source/bam_cat.c
@@ -45,6 +45,8 @@ THE SOFTWARE.
 
 */
 
+#include "bam_cat.h"
+
 #include <stdio.h>
 #include <stdlib.h>
 #include <unistd.h>

--- a/source/bam_cat.c
+++ b/source/bam_cat.c
@@ -16,6 +16,7 @@ Illumina.
 2014-06-27: Alex Dobin modified the code slighlty:
 * to compile with only htslib, no need for samtools package
 * removed the samtools interface function (main)
+* added header file "bam_cat.h"
 
 
 ########## License:

--- a/source/bam_cat.h
+++ b/source/bam_cat.h
@@ -1,0 +1,6 @@
+#ifndef CODE_bam_cat
+#define CODE_bam_cat
+
+int bam_cat(int nfn, char * const *fn, const bam_hdr_t *h, const char* outbam);
+
+#endif

--- a/source/bam_cat.h
+++ b/source/bam_cat.h
@@ -1,6 +1,8 @@
 #ifndef CODE_bam_cat
 #define CODE_bam_cat
 
+#include "htslib/htslib/sam.h"
+
 int bam_cat(int nfn, char * const *fn, const bam_hdr_t *h, const char* outbam);
 
 #endif

--- a/source/sjSplitAlign.cpp
+++ b/source/sjSplitAlign.cpp
@@ -1,3 +1,6 @@
+#include "IncludeDefine.h"                                                                                                                                                     
+#include "Parameters.h"
+
 bool sjAlignSplit(uint a1,uint aLength,Parameters* P, uint &a1D, uint &aLengthD, uint &a1A, uint &aLengthA, uint &isj) {
     uint sj1=(a1-P->sjGstart)%P->sjdbLength;
     if (sj1<P->sjdbOverhang && sj1+aLength>P->sjdbOverhang) {//align crosses the junctions


### PR DESCRIPTION
Include bam_cat.c since it's used in STAR.cpp.

Delete commented-out includes while we're here.