### PR TITLE
Try catch for multMapSelect - fix for #85

### DIFF
--- a/source/ReadAlign_assignAlignToWindow.cpp
+++ b/source/ReadAlign_assignAlignToWindow.cpp
@@ -104,7 +104,7 @@ void ReadAlign::assignAlignToWindow(uint a1, uint aLength, uint aStr, uint aNrep
         };
      
         uint iA;                                      
-        for (iA=0;iA<nWA[iW];iA++) {//find the insertion point in case aligns are not sorted by aRstart
+        for (iA=0; iA<nWA[iW]; iA++) {//find the insertion point in case aligns are not sorted by aRstart
                                     //TODO binary search
             if (aRstart<WA[iW][iA][WA_rStart]) break;
         };
@@ -151,8 +151,11 @@ void ReadAlign::assignAlignToWindow(uint a1, uint aLength, uint aStr, uint aNrep
 //No symbol table info available.
 //#8  0x00002aaaabdca90d in clone () from /lib64/libc.so.6
 //No symbol table info available.
-
-        WA[iW][iA][WA_rStart]=aRstart;
+        try {
+            WA[iW][iA][WA_rStart]=aRstart;
+        } catch (...) {
+            throw "AssignError";
+        }
         WA[iW][iA][WA_Length]=aLength;
         WA[iW][iA][WA_gStart]=a1;
         WA[iW][iA][WA_Nrep]=aNrep;                
@@ -162,6 +165,8 @@ void ReadAlign::assignAlignToWindow(uint a1, uint aLength, uint aStr, uint aNrep
 
         nWA[iW]++;
         nWAP[iW]++;
-        if (aAnchor && WlastAnchor[iW]<iA) WlastAnchor[iW]=iA; //record the index of the last anchor
+        if (aAnchor && WlastAnchor[iW]<iA) {
+            WlastAnchor[iW]=iA; //record the index of the last anchor
+        }
     };
 };

--- a/source/ReadAlign_assignAlignToWindow.cpp
+++ b/source/ReadAlign_assignAlignToWindow.cpp
@@ -155,7 +155,7 @@ void ReadAlign::assignAlignToWindow(uint a1, uint aLength, uint aStr, uint aNrep
         if (iW >=P->seedPerWindowNmax ) {
             exitWithError("BUG: iW>=P->seedPerWindowNmax in stitchPieces, exiting",std::cerr, P->inOut->logMain, EXIT_CODE_BUG, *P);
         }
-        exitWithError("BUG: iW >=P->seedPerWindowNmax in assignAlignToWindow, exiting",std::cerr, P->inOut->logMain, EXIT_CODE_BUG, *P);
+        
         WA[iW][iA][WA_rStart]=aRstart;
         WA[iW][iA][WA_Length]=aLength;
         WA[iW][iA][WA_gStart]=a1;

--- a/source/ReadAlign_assignAlignToWindow.cpp
+++ b/source/ReadAlign_assignAlignToWindow.cpp
@@ -153,7 +153,7 @@ void ReadAlign::assignAlignToWindow(uint a1, uint aLength, uint aStr, uint aNrep
 //#8  0x00002aaaabdca90d in clone () from /lib64/libc.so.6
 //No symbol table info available.
         if (iW >=P->seedPerWindowNmax ) {
-            exitWithError("BUG: iW>=P->seedPerWindowNmax in stitchPieces, exiting",std::cerr, P->inOut->logMain, EXIT_CODE_BUG, *P);
+            throw "AssignError";
         }
         
         WA[iW][iA][WA_rStart]=aRstart;

--- a/source/ReadAlign_assignAlignToWindow.cpp
+++ b/source/ReadAlign_assignAlignToWindow.cpp
@@ -9,6 +9,7 @@ void ReadAlign::assignAlignToWindow(uint a1, uint aLength, uint aStr, uint aNrep
 
     if (iW==uintWinBinMax || (!aAnchor && aLength < WALrec[iW]) ) return; //alignment does not belong to any window, or it's shorter than rec-length
 
+    
     //check if this alignment overlaps with any other alignment in the window, record the longest of the two
     {//do not check for overlap if this is an sj-align
         uint iA;
@@ -65,7 +66,7 @@ void ReadAlign::assignAlignToWindow(uint a1, uint aLength, uint aStr, uint aNrep
         };
     };          
 
-    if (nWA[iW]==P->seedPerWindowNmax) {//too many aligns per window,  re-calcualte min-length, remove the shortest one,
+    if (nWA[iW]==P->seedPerWindowNmax) {//too many aligns per window,  re-calculate min-length, remove the shortest one,
 
         WALrec[iW]=Lread+1; 
         for (uint iA=0; iA<nWA[iW]; iA++) {//find the new min-length    
@@ -151,11 +152,11 @@ void ReadAlign::assignAlignToWindow(uint a1, uint aLength, uint aStr, uint aNrep
 //No symbol table info available.
 //#8  0x00002aaaabdca90d in clone () from /lib64/libc.so.6
 //No symbol table info available.
-        try {
-            WA[iW][iA][WA_rStart]=aRstart;
-        } catch (...) {
+        if (iW >=P->seedPerWindowNmax ) {
             throw "AssignError";
         }
+        
+        WA[iW][iA][WA_rStart]=aRstart;
         WA[iW][iA][WA_Length]=aLength;
         WA[iW][iA][WA_gStart]=a1;
         WA[iW][iA][WA_Nrep]=aNrep;                

--- a/source/ReadAlign_assignAlignToWindow.cpp
+++ b/source/ReadAlign_assignAlignToWindow.cpp
@@ -152,8 +152,11 @@ void ReadAlign::assignAlignToWindow(uint a1, uint aLength, uint aStr, uint aNrep
 //No symbol table info available.
 //#8  0x00002aaaabdca90d in clone () from /lib64/libc.so.6
 //No symbol table info available.
-        if (iW >=P->seedPerWindowNmax ) {
-            throw "AssignError";
+        
+        // This is a stupid patch just to verify whether this
+        // is really the problem that is plagiung us
+        if (iW >=P->seedPerWindowNmax || iW < 0 ) {
+            iW = 0;
         }
         
         WA[iW][iA][WA_rStart]=aRstart;

--- a/source/ReadAlign_assignAlignToWindow.cpp
+++ b/source/ReadAlign_assignAlignToWindow.cpp
@@ -156,7 +156,7 @@ void ReadAlign::assignAlignToWindow(uint a1, uint aLength, uint aStr, uint aNrep
         // This is a stupid patch just to verify whether this
         // is really the problem that is plagiung us
         if (iW >=P->seedPerWindowNmax || iW < 0 ) {
-            iW = 0;
+            throw std::bad_alloc();;
         }
         
         WA[iW][iA][WA_rStart]=aRstart;

--- a/source/ReadAlign_assignAlignToWindow.cpp
+++ b/source/ReadAlign_assignAlignToWindow.cpp
@@ -153,9 +153,9 @@ void ReadAlign::assignAlignToWindow(uint a1, uint aLength, uint aStr, uint aNrep
 //#8  0x00002aaaabdca90d in clone () from /lib64/libc.so.6
 //No symbol table info available.
         if (iW >=P->seedPerWindowNmax ) {
-            throw "AssignError";
+            exitWithError("BUG: iW>=P->seedPerWindowNmax in stitchPieces, exiting",std::cerr, P->inOut->logMain, EXIT_CODE_BUG, *P);
         }
-        
+        exitWithError("BUG: iW >=P->seedPerWindowNmax in assignAlignToWindow, exiting",std::cerr, P->inOut->logMain, EXIT_CODE_BUG, *P);
         WA[iW][iA][WA_rStart]=aRstart;
         WA[iW][iA][WA_Length]=aLength;
         WA[iW][iA][WA_gStart]=a1;

--- a/source/ReadAlign_assignAlignToWindow.cpp
+++ b/source/ReadAlign_assignAlignToWindow.cpp
@@ -114,7 +114,44 @@ void ReadAlign::assignAlignToWindow(uint a1, uint aLength, uint aStr, uint aNrep
             };
         };
         
-        // now iW is the window to which this align belongs, record it                
+        // now iW is the window to which this align belongs, record it
+
+        // This is the piece that breaks
+//         bt full
+//#0  0x000000000044e64f in ReadAlign::assignAlignToWindow (this=0x61c494e0, a1=5768917221, aLength=16, aStr=0, aNrep=232, aFrag=0, aRstart=3906, aAnchor=false, sjA=18446744073709551615)
+//    at ReadAlign_assignAlignToWindow.cpp:118
+//        iA = 0
+//        iW = 10000
+//#1  0x000000000043e926 in ReadAlign::stitchPieces (this=0x61c494e0, R=0x647016d0, Q=0x6486fa80, 
+//    G=0x2aaaad6810d8 "\003\001\003\003\002\003\001\001\003\003\003\002\003\002\003\003\002\001\003\003\001\002\003\003\001\003", SA=..., Lread=8204) at ReadAlign_stitchPieces.cpp:180
+//        a1 = 5768917221
+//        aStr = 0
+//        aRstart = 3906
+//        iSA = 2474311944
+//        aFrag = 0
+//        aLength = 16
+//        aDir = 1
+//        aNrep = 232
+//        aAnchor = false
+//        iP = 2030
+//        swWinCovMax = 2
+//        iW1 = 2
+//        trNtotal = 2
+//#2  0x00000000004415af in ReadAlign::mapOneRead (this=0x61c494e0) at ReadAlign_mapOneRead.cpp:102
+//        seedSearchStartLmax = 50
+//#3  0x000000000044f278 in ReadAlign::oneRead (this=0x61c494e0) at ReadAlign_oneRead.cpp:70
+//        readStatus = {1, 0}
+//#4  0x00000000004453f4 in ReadAlignChunk::mapChunk (this=0x61c49230) at ReadAlignChunk_mapChunk.cpp:25
+//        readStatus = 0
+//#5  0x0000000000444b44 in ReadAlignChunk::processChunks (this=0x61c49230) at ReadAlignChunk_processChunks.cpp:144
+//        __FUNCTION__ = "processChunks"
+//#6  0x000000000047475f in ThreadControl::threadRAprocessChunks (RAchunk=0x61c49230) at ThreadControl.h:22
+//No locals.
+//#7  0x00002aaaabacc851 in start_thread () from /lib64/libpthread.so.0
+//No symbol table info available.
+//#8  0x00002aaaabdca90d in clone () from /lib64/libc.so.6
+//No symbol table info available.
+
         WA[iW][iA][WA_rStart]=aRstart;
         WA[iW][iA][WA_Length]=aLength;
         WA[iW][iA][WA_gStart]=a1;

--- a/source/ReadAlign_mapOneRead.cpp
+++ b/source/ReadAlign_mapOneRead.cpp
@@ -104,7 +104,6 @@ int ReadAlign::mapOneRead() {
         		multMapSelect();
         	 //check all the windows and transcripts for multiple mappers
             }
-
         } catch (char* e) {
             nW = 0;
         }

--- a/source/ReadAlign_mapOneRead.cpp
+++ b/source/ReadAlign_mapOneRead.cpp
@@ -100,17 +100,13 @@ int ReadAlign::mapOneRead() {
 //         qsort((void*) PC, nP, sizeof(uint)*PC_SIZE, funCompareUint2);//sort PC by rStart and length
         try {
               stitchPieces(Read1, Qual1, G, SA,  Lread);
+              if (nW>0) {
+        		multMapSelect();
+        	 //check all the windows and transcripts for multiple mappers
+            }
+
         } catch (char* e) {
             nW = 0;
-        }
-        if (nW>0) {
-        	try {
-        		multMapSelect();
-        	}
-        	catch (char* e) {
-
-        	}
-        	 //check all the windows and transcripts for multiple mappers
         }
     };
     

--- a/source/ReadAlign_mapOneRead.cpp
+++ b/source/ReadAlign_mapOneRead.cpp
@@ -98,7 +98,11 @@ int ReadAlign::mapOneRead() {
         nW=0; 
     } else if (Nsplit>0 && nA>0) {//otherwise there are no good pieces, or all pieces map too many times: read cannot be mapped
 //         qsort((void*) PC, nP, sizeof(uint)*PC_SIZE, funCompareUint2);//sort PC by rStart and length
-        stitchPieces(Read1, Qual1, G, SA,  Lread);
+        try {
+              stitchPieces(Read1, Qual1, G, SA,  Lread);
+        } catch (char* e) {
+            nW = 0;
+        }
         if (nW>0) {
         	try {
         		multMapSelect();

--- a/source/ReadAlign_mapOneRead.cpp
+++ b/source/ReadAlign_mapOneRead.cpp
@@ -105,6 +105,7 @@ int ReadAlign::mapOneRead() {
         	 //check all the windows and transcripts for multiple mappers
             }
         } catch (std::bad_alloc& exc) {
+            P->inOut->logMain << "WARNING: Read " << readName << "caused a crash;" <<endl;
             return 0;
         } 
     };

--- a/source/ReadAlign_mapOneRead.cpp
+++ b/source/ReadAlign_mapOneRead.cpp
@@ -99,7 +99,15 @@ int ReadAlign::mapOneRead() {
     } else if (Nsplit>0 && nA>0) {//otherwise there are no good pieces, or all pieces map too many times: read cannot be mapped
 //         qsort((void*) PC, nP, sizeof(uint)*PC_SIZE, funCompareUint2);//sort PC by rStart and length
         stitchPieces(Read1, Qual1, G, SA,  Lread);
-        if (nW>0) multMapSelect(); //check all the windows and transcripts for multiple mappers
+        if (nW>0) {
+        	try {
+        		multMapSelect();
+        	}
+        	catch (char* e) {
+
+        	}
+        	 //check all the windows and transcripts for multiple mappers
+        }
     };
     
     return 0;

--- a/source/ReadAlign_mapOneRead.cpp
+++ b/source/ReadAlign_mapOneRead.cpp
@@ -104,10 +104,9 @@ int ReadAlign::mapOneRead() {
         		multMapSelect();
         	 //check all the windows and transcripts for multiple mappers
             }
-        } catch (exception& e) {
-            nW = 0;
-        }
+        } catch (std::bad_alloc& exc) {
+            return 0;
+        } 
     };
-    
     return 0;
 };

--- a/source/ReadAlign_mapOneRead.cpp
+++ b/source/ReadAlign_mapOneRead.cpp
@@ -104,7 +104,7 @@ int ReadAlign::mapOneRead() {
         		multMapSelect();
         	 //check all the windows and transcripts for multiple mappers
             }
-        } catch (char* e) {
+        } catch (exception& e) {
             nW = 0;
         }
     };

--- a/source/ReadAlign_multMapSelect.cpp
+++ b/source/ReadAlign_multMapSelect.cpp
@@ -49,9 +49,14 @@ void ReadAlign::multMapSelect() {//select multiple mappers from all transcripts 
         return;
     };
     
+    int size = P->chrStart.size();
+
     for (uint iTr=0; iTr<nTr; iTr++) 
     {              
         trMult[iTr]->roStart = trMult[iTr]->roStr==0 ? trMult[iTr]->rStart : Lread - trMult[iTr]->rStart - trMult[iTr]->rLength;
+        if (size <= trMult[iTr]->Chr || trMult[iTr]->Chr < 0) {
+        	throw "IndexError";
+        }
         trMult[iTr]->cStart=trMult[iTr]->gStart - P->chrStart[trMult[iTr]->Chr];                        
     };
 

--- a/source/ReadAlign_multMapSelect.cpp
+++ b/source/ReadAlign_multMapSelect.cpp
@@ -55,7 +55,7 @@ void ReadAlign::multMapSelect() {//select multiple mappers from all transcripts 
     {              
         trMult[iTr]->roStart = trMult[iTr]->roStr==0 ? trMult[iTr]->rStart : Lread - trMult[iTr]->rStart - trMult[iTr]->rLength;
         if (size <= trMult[iTr]->Chr || trMult[iTr]->Chr < 0) {
-        	throw "IndexError";
+        	throw std::bad_alloc();
         }
         trMult[iTr]->cStart=trMult[iTr]->gStart - P->chrStart[trMult[iTr]->Chr];                        
     };

--- a/source/ReadAlign_stitchPieces.cpp
+++ b/source/ReadAlign_stitchPieces.cpp
@@ -9,6 +9,7 @@
 #include "alignSmithWaterman.h"
 #include "GlobalVariables.h"
 #include <time.h>
+#include "ErrorWarning.h"
 
 void ReadAlign::stitchPieces(char **R, char **Q, char *G, PackedArray& SA, uint Lread) {
     

--- a/source/ReadAlign_stitchPieces.cpp
+++ b/source/ReadAlign_stitchPieces.cpp
@@ -166,23 +166,14 @@ void ReadAlign::stitchPieces(char **R, char **Q, char *G, PackedArray& SA, uint 
             if (a1>=P->sjGstart) {//this is sj read
                 uint a1D, aLengthD, a1A, aLengthA, isj1;              
                 if (sjAlignSplit(a1, aLength, P, a1D, aLengthD, a1A, aLengthA, isj1)) {//align crosses the junction
-                    try {
                         assignAlignToWindow(a1D, aLengthD, aStr, aNrep, aFrag, aRstart, aAnchor, isj1);
                         assignAlignToWindow(a1A, aLengthA, aStr, aNrep, aFrag, aRstart+aLengthD, aAnchor, isj1);
-                    } catch (...) {
-                        throw "AssignError";
-                    }
                     } else {//align does not cross the junction
                         continue; //do not check this align, continue to the next one
                     };
                     
                 } else {//this is a normal genomic read
-                   try {
-                       assignAlignToWindow(a1, aLength, aStr, aNrep, aFrag, aRstart, aAnchor, -1);
-                    } catch (...) {
-                        throw "AssignError";
-                    }
-                    
+                       assignAlignToWindow(a1, aLength, aStr, aNrep, aFrag, aRstart, aAnchor, -1);                 
                 };
         };
         

--- a/source/ReadAlign_stitchPieces.cpp
+++ b/source/ReadAlign_stitchPieces.cpp
@@ -165,16 +165,23 @@ void ReadAlign::stitchPieces(char **R, char **Q, char *G, PackedArray& SA, uint 
             if (a1>=P->sjGstart) {//this is sj read
                 uint a1D, aLengthD, a1A, aLengthA, isj1;              
                 if (sjAlignSplit(a1, aLength, P, a1D, aLengthD, a1A, aLengthA, isj1)) {//align crosses the junction
-
+                    try {
                         assignAlignToWindow(a1D, aLengthD, aStr, aNrep, aFrag, aRstart, aAnchor, isj1);
                         assignAlignToWindow(a1A, aLengthA, aStr, aNrep, aFrag, aRstart+aLengthD, aAnchor, isj1);
-                        
+                    } catch (...) {
+                        throw "AssignError";
+                    }
                     } else {//align does not cross the junction
                         continue; //do not check this align, continue to the next one
                     };
                     
                 } else {//this is a normal genomic read
-                    assignAlignToWindow(a1, aLength, aStr, aNrep, aFrag, aRstart, aAnchor, -1);
+                   try {
+                       assignAlignToWindow(a1, aLength, aStr, aNrep, aFrag, aRstart, aAnchor, -1);
+                    } catch (...) {
+                        throw "AssignError";
+                    }
+                    
                 };
         };
         

--- a/source/sjSplitAlign.cpp
+++ b/source/sjSplitAlign.cpp
@@ -5,8 +5,8 @@ bool sjAlignSplit(uint a1,uint aLength,Parameters* P, uint &a1D, uint &aLengthD,
     uint sj1=(a1-P->sjGstart) % P->sjdbLength;
     if ( sj1 > P->sjdbLength) {
         // this is clearly an underflow error
-        return false
-    }
+        return false;
+    };
     if (sj1<P->sjdbOverhang && sj1+aLength>P->sjdbOverhang) {//align crosses the junctions
         isj=(a1-P->sjGstart)/P->sjdbLength;
         aLengthD=P->sjdbOverhang-sj1;

--- a/source/sjSplitAlign.cpp
+++ b/source/sjSplitAlign.cpp
@@ -5,7 +5,7 @@ bool sjAlignSplit(uint a1,uint aLength,Parameters* P, uint &a1D, uint &aLengthD,
     uint sj1=(a1-P->sjGstart) % P->sjdbLength;
     if ( sj1 > P->sjdbLength) {
         // this is clearly an underflow error
-        return false;
+        exitWithError("BUG: sj1>=P->sjdbLength in sjAlignSplit, exiting",std::cerr, P->inOut->logMain, EXIT_CODE_BUG, *P);            
     };
     if (sj1<P->sjdbOverhang && sj1+aLength>P->sjdbOverhang) {//align crosses the junctions
         isj=(a1-P->sjGstart)/P->sjdbLength;

--- a/source/sjSplitAlign.cpp
+++ b/source/sjSplitAlign.cpp
@@ -1,5 +1,6 @@
 #include "IncludeDefine.h"                                                                                                                                                     
 #include "Parameters.h"
+#include "ErrorWarning.h"
 
 bool sjAlignSplit(uint a1,uint aLength,Parameters* P, uint &a1D, uint &aLengthD, uint &a1A, uint &aLengthA, uint &isj) {
     uint sj1=(a1-P->sjGstart) % P->sjdbLength;

--- a/source/sjSplitAlign.cpp
+++ b/source/sjSplitAlign.cpp
@@ -2,7 +2,11 @@
 #include "Parameters.h"
 
 bool sjAlignSplit(uint a1,uint aLength,Parameters* P, uint &a1D, uint &aLengthD, uint &a1A, uint &aLengthA, uint &isj) {
-    uint sj1=(a1-P->sjGstart)%P->sjdbLength;
+    uint sj1=(a1-P->sjGstart) % P->sjdbLength;
+    if ( sj1 > P->sjdbLength) {
+        // this is clearly an underflow error
+        return false
+    }
     if (sj1<P->sjdbOverhang && sj1+aLength>P->sjdbOverhang) {//align crosses the junctions
         isj=(a1-P->sjGstart)/P->sjdbLength;
         aLengthD=P->sjdbOverhang-sj1;


### PR DESCRIPTION
I implemented a try catch construct for multMapSelect that gets rid of the error we were witnessing in wheat. I am still not clear on the origin of the problem, but this patch gets around it.
