### PR TITLE
Removes compiler warnings

### DIFF
--- a/source/BAMfunctions.cpp
+++ b/source/BAMfunctions.cpp
@@ -4,10 +4,8 @@
 string bam_cigarString (bam1_t *b) {//output CIGAR string
 //    kstring_t strK;
 //    kstring_t *str=&strK;
-    const bam1_core_t *c = &b->core;
-
     string cigarString("");
-    if ( c->n_cigar > 0 ) {
+    if ( b->core->n_cigar > 0 ) {
       uint32_t *cigar = bam_get_cigar(b);
       for (int i = 0; i < c->n_cigar; ++i) {
         cigarString+=to_string((uint)bam_cigar_oplen(cigar[i]))+bam_cigar_opchr(cigar[i]);

--- a/source/BAMfunctions.cpp
+++ b/source/BAMfunctions.cpp
@@ -1,11 +1,16 @@
 #include "BAMfunctions.h"
 #include "htslib/htslib/kstring.h"
 
+
+///@todo string bam_cigarString (bam1_t *b,  bam1_core_t *c)   will save unnecessairy casts
 string bam_cigarString (bam1_t *b) {//output CIGAR string
 //    kstring_t strK;
 //    kstring_t *str=&strK;
+    
+    const bam1_core_t *c = &b->core;
+
     string cigarString("");
-    if ( b->core->n_cigar > 0 ) {
+    if ( c->n_cigar > 0 ) {
       uint32_t *cigar = bam_get_cigar(b);
       for (int i = 0; i < c->n_cigar; ++i) {
         cigarString+=to_string((uint)bam_cigar_oplen(cigar[i]))+bam_cigar_opchr(cigar[i]);
@@ -24,10 +29,11 @@ string bam_cigarString (bam1_t *b) {//output CIGAR string
     return cigarString;
 };
 
+///@todo int bam_read1_fromArray(bam1_t *b,  &b->core, bam1_core_t *c)   will save unnecessairy casts
 int bam_read1_fromArray(char *bamChar, bam1_t *b) //modified from samtools bam_read1 to assign BAM record in mmemry to bam structure
 {
 	bam1_core_t *c = &b->core;
-	int32_t block_len, ret, i;
+	int32_t block_len;
 // // 	uint32_t x[8];
 // // 	if ((ret = bgzf_read(fp, &block_len, 4)) != 4) {
 // // 		if (ret == 0) return -1; // normal end-of-file

--- a/source/Parameters.cpp
+++ b/source/Parameters.cpp
@@ -1079,7 +1079,7 @@ void Parameters::inputParameters (int argInN, char* argIn[]) {//input parameters
     
     //chimeric
     chimPar.filter.genomicN=false;
-    for (int ii=0; ii<chimFilter.size(); ii++)
+    for (unsigned int ii=0; ii<chimFilter.size(); ii++)
     {
         if (chimFilter.at(ii)=="banGenomicN")
         {
@@ -1097,7 +1097,7 @@ void Parameters::inputParameters (int argInN, char* argIn[]) {//input parameters
         };
     };
     
-    for (int ii=0; ii<readNameSeparator.size(); ii++)
+    for (unsigned int ii=0; ii<readNameSeparator.size(); ii++)
     {
         if (readNameSeparator.at(ii)=="space")
         {
@@ -1218,7 +1218,7 @@ void Parameters::chrInfoLoad() {//find chrStart,Length,nChr from Genome G
     
     while (chrStreamIn.good()) {
         string chrIn;
-        char chrInChar[1000];
+        char chrInChar[1000];///@todo figure out whether this declaration must not be out of the loop (should save mem allocs)
         chrStreamIn.getline(chrInChar,1000);
         chrIn=chrInChar;
         if (chrIn=="") break;

--- a/source/Parameters_openReadsFiles.cpp
+++ b/source/Parameters_openReadsFiles.cpp
@@ -45,7 +45,7 @@ void Parameters::openReadsFiles() {
                 readsCommandFile << "#!" <<sysShell <<"\n";
             };
             readsCommandFile << "exec > \""<<readFilesInTmp.at(imate)<<"\"\n" ; // redirect stdout to temp fifo files
-                        
+            
             string readFilesInString(readFilesIn.at(imate));
             size_t pos=0;
             readFilesN=0;

--- a/source/ReadAlign_chimericDetection.cpp
+++ b/source/ReadAlign_chimericDetection.cpp
@@ -357,9 +357,9 @@ bool ReadAlign::chimericDetection() {
                             mateChr=-1;mateStart=-1;mateStrand=0;//no need fot mate info unless this is the supplementary alignment
                             if (chimRepresent==itr) {
                                 alignType=-1; //this is representative part of chimeric alignment, record is as normal; if encompassing chimeric junction, both are recorded as normal
-                                bamIrepr=( (itr%2)==(trChim[itr].Str) && chimType!=3) ? bamN+1 : bamN;//this is the mate that is chimerically split
+                                bamIrepr=( (uint) (itr%2)==(trChim[itr].Str) && chimType!=3) ? bamN+1 : bamN;//this is the mate that is chimerically split
                             } else {//"supplementary" chimeric segment
-                                alignType=( (itr%2)==(trChim[itr].Str) ) ? -12 : -11; //right:left chimeric junction
+                                alignType=( (uint) (itr%2)==(trChim[itr].Str) ) ? -12 : -11; //right:left chimeric junction
                                 bamIsuppl=bamN;
                                 if (chimType==1) {//PE alignment, need mate info for the suppl
                                     uint iex=0;

--- a/source/ReadAlign_mapOneRead.cpp
+++ b/source/ReadAlign_mapOneRead.cpp
@@ -49,7 +49,7 @@ int ReadAlign::mapOneRead() {
 //               #else
                 if (flagDirMap || istart>0) {//check if the 1st piece in reveree direction does not need to be remapped
                     Lmapped=0;
-                    uint Nrep2=0;
+                    //uint Nrep2=0;
                     while ( istart*Lstart + Lmapped + P->minLmap < splitR[1][ip] ) {//map until unmapped portion is <=minLmap
 
                         uint Shift = iDir==0 ? ( splitR[0][ip] + istart*Lstart + Lmapped ) : \
@@ -57,7 +57,7 @@ int ReadAlign::mapOneRead() {
 
 //                         uint seedLength=min(splitR[1][ip] - Lmapped - istart*Lstart, P->seedSearchLmax);
                         uint seedLength=splitR[1][ip] - Lmapped - istart*Lstart;
-                        Nrep2=maxMappableLength2strands(Shift, seedLength, iDir, 0, P->nSA-1, L, splitR[2][ip]);//L=max mappable length, unique or multiple
+                        //Nrep2=maxMappableLength2strands(Shift, seedLength, iDir, 0, P->nSA-1, L, splitR[2][ip]);//L=max mappable length, unique or multiple
                         if (iDir==0 && istart==0 && Lmapped==0 && Shift+L == splitR[1][ip] ) {//this piece maps full length and does not need to be mapped from the opposite direction
                             flagDirMap=false;
                         };

--- a/source/ReadAlign_outputTranscriptSAM.cpp
+++ b/source/ReadAlign_outputTranscriptSAM.cpp
@@ -243,7 +243,7 @@ uint ReadAlign::outputTranscriptSAM(Transcript const &trOut, uint nTrOut, uint i
             };      
             tagMD+=to_string(matchN);
         };
-        for (int ii=0;ii<P->outSAMattrOrder.size();ii++) {
+        for (uint ii=0;ii<P->outSAMattrOrder.size();ii++) {
             switch (P->outSAMattrOrder[ii]) {
                 case ATTR_NH:
                     *outStream <<"\tNH:i:" << nTrOut;

--- a/source/ReadAlign_stitchWindowSeeds.cpp
+++ b/source/ReadAlign_stitchWindowSeeds.cpp
@@ -130,7 +130,7 @@ void ReadAlign::stitchWindowSeeds (uint iW, uint iWrec, char* R, char* Q, char* 
         trA.maxScore=Score;
         
         {//extend to the left
-            uint iS1=seedChain[seedN-1];
+            //uint iS1=seedChain[seedN-1];
             trA1=*trInit;
             if ( trA.exons[0][EX_R]>0 \
                  && extendAlign(R, Q, G, trA.exons[0][EX_R]-1, trA.exons[0][EX_G]-1, -1, -1, trA.exons[0][EX_R], 100000, 0, outFilterMismatchNmaxTotal, P->outFilterMismatchNoverLmax, 
@@ -252,13 +252,15 @@ void ReadAlign::stitchWindowSeeds (uint iW, uint iWrec, char* R, char* Q, char* 
         
         
         //check exons lenghts including repeats, do not report a transcript with short exons
-//        for (uint isj=0;isj<trA.nExons-1;isj++) {//check exons for min length, if they precede a junction
-//            if ( trA.canonSJ[isj]>=0 && \
-//               ( trA.exons[isj][EX_L] < P->alignSJoverhangMin + trA.shiftSJ[isj][0] \
-//              || trA.exons[isj+1][EX_L] < P->alignSJoverhangMin + trA.shiftSJ[isj][1]) ) {                  
-//                return;//do not record this transcript in wTr
-//            };
-//        };          
+/*
+        for (uint isj=0;isj<trA.nExons-1;isj++) {//check exons for min length, if they precede a junction
+            if ( trA.canonSJ[isj]>=0 && \
+               ( trA.exons[isj][EX_L] < P->alignSJoverhangMin + trA.shiftSJ[isj][0] \
+              || trA.exons[isj+1][EX_L] < P->alignSJoverhangMin + trA.shiftSJ[isj][1]) ) {                  
+                return;//do not record this transcript in wTr
+            };
+        };          
+*/
     };
     
     {//record the transcript TODO: allow for multiple transcripts in one window

--- a/source/STAR.cpp
+++ b/source/STAR.cpp
@@ -159,7 +159,7 @@ int main(int argInN, char* argIn[]) {
         P->inOut->logProgress << timeMonthDayTime(rawtime) <<"\tFinished 1st pass mapping\n";
         *P->inOut->logStdOut << timeMonthDayTime(rawtime) << " ..... Finished 1st pass mapping\n" <<flush;
         ofstream logFinal1 ( (P->twoPass.dir + "/Log.final.out").c_str());
-        g_statsAll.reportFinal(logFinal1,P1);
+        g_statsAll.reportFinal(logFinal1);
 
         P->twoPass.pass2=true;//starting the 2nd pass
         P->twoPass.pass1sjFile=P->twoPass.dir+"/SJ.out.tab";
@@ -412,7 +412,7 @@ int main(int argInN, char* argIn[]) {
     g_statsAll.progressReport(P->inOut->logProgress);
     P->inOut->logProgress  << "ALL DONE!\n"<<flush;
     P->inOut->logFinal.open((P->outFileNamePrefix + "Log.final.out").c_str());
-    g_statsAll.reportFinal(P->inOut->logFinal,P);
+    g_statsAll.reportFinal(P->inOut->logFinal);
     *P->inOut->logStdOut << timeMonthDayTime(g_statsAll.timeFinish) << " ..... Finished successfully\n" <<flush;
     
     P->inOut->logMain  << "ALL DONE!\n"<<flush;
@@ -421,6 +421,7 @@ int main(int argInN, char* argIn[]) {
     P->closeReadsFiles();//this will kill the readFilesCommand processes if necessary
     mainGenome.~Genome(); //need explicit call because of the 'delete P->inOut' below, which will destroy P->inOut->logStdOut
     
+    ///@todo create Destructor to destroy P->inOut
     delete P->inOut; //to close files
     delete P;
     

--- a/source/Stats.cpp
+++ b/source/Stats.cpp
@@ -94,7 +94,7 @@ void Stats::progressReport(ofstream &progressStream) {
     };
 };
 
-void Stats::reportFinal(ofstream &streamOut, Parameters *P) {    
+void Stats::reportFinal(ofstream &streamOut) {    
     int w1=50;
     time( &timeFinish);    
     

--- a/source/SuffixArrayFuns.cpp
+++ b/source/SuffixArrayFuns.cpp
@@ -188,14 +188,15 @@ uint maxMappableLength(char** s, uint S, uint N, char* g, PackedArray& SA, uint 
     return i2-i1+1;
 };
 
-uint suffixArraySearch(char** s2, uint S, uint N, char* G, PackedArray& SA, bool dirR, uint i1, uint i2, uint L, Parameters* P) {
+/*
+uint suffixArraySearch(char** s2, uint S, uint N, char* G, PackedArray& SA, uint i1, uint i2, uint L, Parameters* P) {
     // binary search in SA space
     // s[0],s[1] - sequence, complementary sequence
     // S - start offset
     // N - sequence length
     // g - genome sequence
     // SA - suffix array
-    // dirR - direction, true=froward, false=reverse!!!!!!!NOT WORKING
+    ///@todo dirR - direction, true=froward, false=reverse!!!!!!!NOT WORKING
     // i1,i2 = starting indices in SA    
     // L - starting length
     // output: SA index < searched string, i.e. g[SA[index]]<s<g[SA[index+1]]
@@ -271,6 +272,7 @@ uint suffixArraySearch(char** s2, uint S, uint N, char* G, PackedArray& SA, bool
     };
     return i1;
 };
+*/
 
 int compareRefEnds (uint64 SAstr,  uint64 gInsert, bool strG, bool strR, Parameters* P)
 {
@@ -328,7 +330,9 @@ uint compareSeqToGenome1(char** s2, uint S, uint N, uint L, char* g, PackedArray
         };
 //         if (s[ii]>g[ii]) {compRes=true;} else {compRes=false;};        
         return N; //exact match
-    } else if (!dirG) {
+    }
+    else
+    {
         char* s  = s2[1] + S + L;
         g += P->nGenome-1-SAstr - L;
         for (ii=0; (uint) ii < N-L; ii++)

--- a/source/bamRemoveDuplicates.cpp
+++ b/source/bamRemoveDuplicates.cpp
@@ -20,7 +20,7 @@ int funCompareNames(const void *a, const void *b) {//compare read names
     compareReturn(la,lb) else {
         char* ca=(char*) (pa+9);
         char* cb=(char*) (pb+9);
-        for (int ii=0;ii<la;ii++) {
+        for (uint32 ii=0;ii<la;ii++) {
             compareReturn(ca[ii],cb[ii]);
         };
         uint32 fa=pa[4]>>16;

--- a/source/extendAlign.cpp
+++ b/source/extendAlign.cpp
@@ -23,7 +23,7 @@ if (extendToEnd) {//end to end extension
         iS=dR*iExt;
         iG=dG*iExt;
 
-        if ((gStart+iG)==-1 || G[iG]==5) {//prohibit extension through chr boundary
+        if ((iG + (int) gStart)==-1 || G[iG]==5) {//prohibit extension through chr boundary
             trA->extendL=0;
             trA->maxScore=-999999999;
             trA->nMatch=0;
@@ -61,7 +61,7 @@ for (int i=0;i<(int) L;i++) {
     iS=dR*i;
     iG=dG*i;
     
-    if ((gStart+iG)==-1 || G[iG]==5 || R[iS]==MARK_FRAG_SPACER_BASE) break; //no extension through chr boundary, or through the spacer between fragments
+    if (((int) gStart+iG)==-1 || G[iG]==5 || R[iS]==MARK_FRAG_SPACER_BASE) break; //no extension through chr boundary, or through the spacer between fragments
     if (R[iS]>3 || G[iG]>3) continue;//no penalties for Ns in reads or genome
     
     if (G[iG]==R[iS]) {//Match

--- a/source/genomeSAindex.cpp
+++ b/source/genomeSAindex.cpp
@@ -180,7 +180,7 @@ void genomeSAindexChunk(char * G, PackedArray & SA, Parameters * P, PackedArray 
 //                 cout<< iL <<" "<< isa <<" "<< indPref <<" "<<indPref1<<endl;
             
 
-            if ( iL==iL4 ) {//this suffix contains N and does not belong in SAi
+            if ( iL== (uint) iL4 ) {//this suffix contains N and does not belong in SAi
                 for (uint iL1=iL; iL1 < P->genomeSAindexNbases; iL1++) {
                     SAi.writePacked(P->genomeSAindexStart[iL1]+ind0[iL1],SAi[P->genomeSAindexStart[iL1]+ind0[iL1]] | P->SAiMarkNmaskC);
 //                     if (SAi[P->genomeSAindexStart[iL]+ind0[iL1]] != SAi1[P->genomeSAindexStart[iL]+ind0[iL1]])

--- a/source/stitchAlignToTranscript.cpp
+++ b/source/stitchAlignToTranscript.cpp
@@ -299,7 +299,7 @@ intScore stitchAlignToTranscript(uint rAend, uint gAend, uint rBstart, uint gBst
                 
         #else
             if ( (trA->nMM + nMM)<=outFilterMismatchNmaxTotal  \
-                         && ( jCan<0 || (jCan<7 && nMM<=P->alignSJstitchMismatchNmax[(jCan+1)/2]) ) ) 
+                         && ( jCan<0 || (jCan<7 && nMM<= (int) P->alignSJstitchMismatchNmax[(jCan+1)/2]) ) ) 
         #endif
             {//stitching worked only if there no mis-matches for non-GT/AG junctions
                 trA->nMM += nMM;

--- a/source/sysRemoveDir.cpp
+++ b/source/sysRemoveDir.cpp
@@ -4,6 +4,7 @@
 #include <ftw.h>
 #include <unistd.h>
 
+
 int removeFileOrDir(const char *fpath,const struct stat *sb, int typeflag, struct FTW *ftwbuf) {
     if (typeflag==FTW_F) {//file
         remove(fpath);


### PR DESCRIPTION
Compilation gives quite some warnings. Most of them are simple int vs uint comparisons and unused declared variables. In this PR I fixed some of them but there are still a few warnings left.

In source/Parameters.cpp I found the following code:

```
     while (chrStreamIn.good()) {
         string chrIn;
        char chrInChar[1000];
```

If I'm not mistaken `chrInChar` gets (re-)allocated for every 1000 input chars. Putting the initiazation out of the loop seems more approprate to me. If you agree I'll make the change.


In source/SuffixArrayFuns.cpp I found the following line:
`    } else if (!dirG) {`
This is an elseif on a boolean, which should always happen if the previous if statement returns false. I have simply changed it to `else` and since the "!" is one additional cpu operation it should have become a bit faster.