### PR TITLE
Helping the optical impression of status messages - just a tiny bit

### DIFF
--- a/source/STAR.cpp
+++ b/source/STAR.cpp
@@ -56,7 +56,7 @@ int main(int argInN, char* argIn[]) {
     Parameters *P = new Parameters; //all parameters
     P->inputParameters(argInN, argIn);
 
-    *(P->inOut->logStdOut) << timeMonthDayTime(g_statsAll.timeStart) << " ..... Started STAR run\n" <<flush;
+    *(P->inOut->logStdOut) << timeMonthDayTime(g_statsAll.timeStart) << " ..... started STAR run\n" <<flush;
 
     //generate genome
     if (P->runMode=="genomeGenerate") {

--- a/source/genomeGenerate.cpp
+++ b/source/genomeGenerate.cpp
@@ -141,8 +141,8 @@ void genomeGenerate(Parameters *P) {
     string timeString;
 
     time(&rawTime);
-    P->inOut->logMain     << timeMonthDayTime(rawTime) <<" ... Starting to generate Genome files\n" <<flush;
-    *P->inOut->logStdOut  << timeMonthDayTime(rawTime) <<" ... Starting to generate Genome files\n" <<flush;
+    P->inOut->logMain     << timeMonthDayTime(rawTime) <<" ... starting to generate Genome files\n" <<flush;
+    *P->inOut->logStdOut  << timeMonthDayTime(rawTime) <<" ... starting to generate Genome files\n" <<flush;
 
     //define some parameters from input parameters
     P->genomeChrBinNbases=1LLU << P->genomeChrBinNbits;


### PR DESCRIPTION
Hello,
here I am, starring at
<pre>
STAR --runThreadN 6 --runMode genomeGenerate --genomeDir genome --genomeFastaFiles genome/GRCh38.fasta --sjdbGTFfile genome/GRCh38.gtf
Feb 25 13:21:59 ..... Started STAR run
Feb 25 13:21:59 ... Starting to generate Genome files
Feb 25 13:23:31 ... starting to sort  Suffix Array. This may take a long time...
Feb 25 13:23:59 ... sorting Suffix Array chunks and saving them to disk...
</pre>
for a while now and, well, I presume I should be doing some else, but it kept nagging me that "Starting" is appearing both with a capital and a lower case S/s. I may be missing some higher semantics of that case issue, but though that you may possibly feel like deciding for an all lower-case scenario.

While I was at it, I found another "Starting", but this time with no leading dots, at source/ReadAlignChunk_processChunks.cpp . Maybe this means that an all upper-case is preferable. Donno. Just something that does not feed that Asperger animal in us too much, please.

Cheers,

Steffen

PS: And I very much hope my 3rd contribution will eventually be somewhat more useful.