### PR TITLE
Don't exit when fastq contains a zero-length read

### DIFF
--- a/source/readLoad.cpp
+++ b/source/readLoad.cpp
@@ -37,7 +37,7 @@ int readLoad(istream& readInStream, Parameters* P, uint iMate, uint& Lread, uint
     readInStream.getline(Seq,DEF_readSeqLengthMax+1); //extract sequence
 
     Lread=(uint) readInStream.gcount();
-    if (Lread<=1) {
+    if (Lread<1) {
         ostringstream errOut;
         errOut << "EXITING because of FATAL ERROR in reads input: short read sequence line: " << Lread <<"\n";
         errOut << "Read Name="<<readName<<"\n";


### PR DESCRIPTION
We've recently had fastq files with a few zero length reads.  This commit allows STAR to skip over them without exiting