### PR TITLE
Fix hardcoded rm path in Makefile

### DIFF
--- a/source/Makefile
+++ b/source/Makefile
@@ -86,7 +86,7 @@ ifneq ($(MAKECMDGOALS),STARforMac)
 ifneq ($(MAKECMDGOALS),STARforMacGDB)
 Depend.list: $(SOURCES) parametersDefault.xxd htslib
 	echo $(SOURCES)
-	/bin/rm -f ./Depend.list
+	rm -f ./Depend.list
 	$(CXX) $(CXXFLAGS_common) -MM $^ >> Depend.list
 include Depend.list
 endif


### PR DESCRIPTION
Hardcoded /bin/rm makes it necessary to patch Makefile in order to package STAR for NixOS:

https://github.com/NixOS/nixpkgs/pull/34156/files#diff-c9a5b115b2affe2b2b24cf9c99484d17

@alexdobin 