### PR TITLE
Fix Segmentation Fault Under Certain Conditions

### DIFF
--- a/source/ReadAlign_maxMappableLength2strands.cpp
+++ b/source/ReadAlign_maxMappableLength2strands.cpp
@@ -58,12 +58,7 @@ uint ReadAlign::maxMappableLength2strands(uint pieceStartIn, uint pieceLengthIn,
         maxL=0;
         Nrep = maxMappableLength(mapGen, Read1, pieceStart, pieceLength, iSA1 & mapGen.SAiMarkNmask, iSA2, dirR, maxL, indStartEnd);
     #else
-        if (Lind < P.pGe.gSAindexNbases && (iSA1 & mapGen.SAiMarkNmaskC)==0 ) {//no need for SA search
-            indStartEnd[0]=iSA1;
-            indStartEnd[1]=iSA2;
-            Nrep=indStartEnd[1]-indStartEnd[0]+1;
-            maxL=Lind;
-        } else if (iSA1==iSA2) {//unique align already, just find maxL
+        if (iSA1==iSA2) {//unique align already, just find maxL
             if ((iSA1 & mapGen.SAiMarkNmaskC)!=0) {
                 ostringstream errOut;
                 errOut  << "BUG: in ReadAlign::maxMappableLength2strands";
@@ -75,7 +70,8 @@ uint ReadAlign::maxMappableLength2strands(uint pieceStartIn, uint pieceLengthIn,
             maxL=compareSeqToGenome(mapGen, Read1, pieceStart, pieceLength, Lind, iSA1, dirR, comparRes);
         } else {//SA search, pieceLength>maxL
         if ( (iSA1 & mapGen.SAiMarkNmaskC)==0 ) {//no N in the prefix
-                maxL=Lind;
+                bool cres;
+                maxL=compareSeqToGenome(mapGen, Read1, pieceStart, pieceLength, 0, iSA2, dirR, cres);
             } else {
                 maxL=0;
             };


### PR DESCRIPTION
This PR was motivated by a SIGSEGV that STAR produced when aligning a particular read against the Rabbit genome. The problem is reproducible, and a file with the rabbit genome and one read that produces the error is available [here](https://support.10xgenomics.com/transfers/f5f435b5d8f1aa09).

After downloading, the following command will exit with a SIGSEGV

    STAR --genomeDir rabbit --outSAMmultNmax -1 --readFilesIn temp.fastq 

I'd love to integrate a fix for this problem, and attempted one with this PR.

I diagnosed the issue as follows. In trying to map the read, the aligner routine within ReadAlign::maxMappableLength2strands was trying to find exact matches for the end of the read. The first step in this process is looking up a given prefix length in the suffix array index. This index contains minimum (and maximum) locations for prefixes up to size L_max (14 in this case). For this particular read segment, no prefix of size 14 was found, so the program re-attempted to search the index with a prefix of size 13, which it did find. Because a prefix of size 13 and not 14 was found, the program knew there was no match of size 14 and so tried to set the end of the search range in the suffix array (`indStartEnd[1]`) using a short-cut that avoids the binary search. In particular, it set the End of the bounded range to the value of one minus the next element in the index.

However, it appears not all elements prior to the start of the next prefix are guaranteed to match the current prefix. In this particular case, that next element pointed to a position 10 bases before the end of the genome, which meant it could not produce an alignment 13 bases in length. Later on inside `ReadAlign::stitchPieces` and its call to `sjSplitAlign` this led to the SIGSEGV when while calculating the alignment start position it inferred to be 3 basepairs past the end of the genome, giving an offset position of -3 which when converted to an unsigned integer has value 18446744073709551613, and consequently the calculated value for `isj` in the code line `P->sjDstart[isj]` referred to unmapped memory, leading to the SIGSEGV.

I believe this can happen as the suffix array can be sorted as follows:

    ACTGAAAA <- iSA1 / first prefix
    ACTGNNNN <- iSA2
    ACTTACTG <- next prefix

Since it seemed the short-cut avoiding the binary-search was not reliable, I removed it with this commit. Since it also appeared that this was a general problem where one could not guarantee the initial range guessed held matching prefixes up to the prefix length tested, I also changed the binary search to account for this. Testing showed for particular read this had these changes restored the correct behavior in the inferred bounds (as determined by doing a full binary search).