### PR TITLE
Bring Dockerfile up to date with current release

### DIFF
--- a/extras/docker/Dockerfile
+++ b/extras/docker/Dockerfile
@@ -2,7 +2,7 @@ FROM debian:stretch-slim
 
 MAINTAINER dobin@cshl.edu
 
-ENV STAR_VERSION 2.6.1d
+ENV STAR_VERSION 2.7.0a
 
 ENV PACKAGES gcc g++ make wget zlib1g-dev
 


### PR DESCRIPTION
Updating version number in the dockerfile to pull the most current release when building the image