### PR TITLE
Fix compilation error for undeclared `pow`.

### DIFF
--- a/source/SoloReadFeature_inputRecords.cpp
+++ b/source/SoloReadFeature_inputRecords.cpp
@@ -1,5 +1,6 @@
 #include "SoloReadFeature.h"
 #include "binarySearch2.h"
+#include <math.h>
 
 bool inputFeatureUmi(fstream *strIn, int32 featureType, uint32 &feature, uint32 &umi, array<vector<uint64>,2> &sjAll)
 {


### PR DESCRIPTION
Added include for `<math.h>` as seen in another source file.