### PR TITLE
Add support for cell barcodes which are longer than 16 nucleotides.

### DIFF
--- a/source/ParametersSolo.cpp
+++ b/source/ParametersSolo.cpp
@@ -21,6 +21,13 @@ void ParametersSolo::initialize(Parameters *pPin)
         if (bL==1)
             bL=cbL+umiL;
         pP->readNmates=1; //output mates TODO: check that readNmatesIn==2
+
+        if (umiL > 16) {
+            ostringstream errOut;
+            errOut << "EXITING because of to high UMI length: --soloUMIlen="<<umiL<<"\n";
+            errOut << "SOLUTION: specify lower UMI length (max: 16)";
+            exitWithError(errOut.str(),std::cerr, pP->inOut->logMain, EXIT_CODE_PARAMETER, *pP);
+        }
     } else  {
         ostringstream errOut;
         errOut << "EXITING because of fatal PARAMETERS error: unrecognized option in --soloType="<<typeStr<<"\n";
@@ -111,17 +118,17 @@ void ParametersSolo::initialize(Parameters *pPin)
             errOut << "SOLUTION: make sure that the barcode read is the second in --readFilesIn and check that is has the correct formatting\n";
             exitWithError(errOut.str(),std::cerr, pP->inOut->logMain, EXIT_CODE_INPUT_FILES, *pP);
         };
-        uint32 cb1;
+        uint64 cb1;
         //convert to 2-bit format
-        if (convertNuclStrToInt32(seq1,cb1)) {
+        if (convertNuclStrToInt64(seq1,cb1)) {
             //cbWL.insert(cb1);
             cbWL.push_back(cb1);
         } else {
             pP->inOut->logMain << "WARNING: CB whitelist sequence contains non-ACGT and is ignored: " << seq1 <<endl;
         };
     };
-    //int comp1 = [] (const void *a, const void *b) {uint32 aa=*(uint32*) a; uint32 bb=*(uint32*) b; if (a
-    qsort(cbWL.data(),cbWL.size(),sizeof(uint32),funCompareNumbers<uint32>);
+
+    qsort(cbWL.data(),cbWL.size(),sizeof(uint64),funCompareNumbers<uint64>);
 
     if (!pP->quant.trSAM.yes) {
         pP->quant.yes = true;

--- a/source/ParametersSolo.h
+++ b/source/ParametersSolo.h
@@ -13,7 +13,7 @@ public:
     uint32 umiS,umiL; //umi start,length
     uint32 bL; //total barcode length
     string soloCBwhitelist;
-    std::vector <uint32> cbWL;
+    std::vector <uint64> cbWL;
     string strandStr;
     int32 strand;
     //features

--- a/source/SequenceFuns.cpp
+++ b/source/SequenceFuns.cpp
@@ -219,6 +219,37 @@ string convertNuclInt32toString(uint32 nuclNum, const uint32 L) {
         nuclOut[L-ii] = nuclChar[nuclNum & 3];
         nuclNum = nuclNum >> 2;
     };
+
+    return nuclOut;
+};
+
+int64 convertNuclStrToInt64(const string S, uint64 &intOut) {
+    intOut=0;
+    int64 posN=-1;
+    for (uint64 ii=0; ii<S.size(); ii++) {
+        uint64 nt = (uint64) convertNt01234(S.at(ii));
+        if (nt>3) {//N
+            if (posN>=0)
+                return -2; //two Ns
+            posN=ii;
+            nt=0;
+        };
+        intOut = intOut << 2;
+        intOut +=nt;
+        //intOut += nt<<(2*ii);
+    };
+    return posN;
+};
+
+string convertNuclInt64toString(uint64 nuclNum, const uint32 L) {
+    string nuclOut(L,'N');
+    string nuclChar="ACGT";
+
+    for (uint64 ii=1; ii<=L; ii++) {
+        nuclOut[L-ii] = nuclChar[nuclNum & 3];
+        nuclNum = nuclNum >> 2;
+    };
+
     return nuclOut;
 };
 

--- a/source/SequenceFuns.h
+++ b/source/SequenceFuns.h
@@ -24,4 +24,7 @@ uint qualitySplit(char*, char*, uint, char, uint, uint, uint**);
 int32 convertNuclStrToInt32(const string S, uint32 &intOut);
 string convertNuclInt32toString(const uint32 nuclNum, const uint32 L);
 
+int64 convertNuclStrToInt64(const string S, uint64 &intOut);
+string convertNuclInt64toString(const uint64 nuclNum, const uint32 L);
+
 #endif

--- a/source/SoloFeature_outputResults.cpp
+++ b/source/SoloFeature_outputResults.cpp
@@ -17,7 +17,7 @@ void SoloFeature::outputResults()
         //output CBs
         ofstream &cbStr=ofstrOpen(P.outFileNamePrefix+pSolo.outFileNames[0]+pSolo.outFileNames[2],ERROR_OUT, P);
         for (auto const &cb : pSolo.cbWL)
-            cbStr << convertNuclInt32toString(cb,pSolo.cbL)  <<'\n';
+            cbStr << convertNuclInt64toString(cb,pSolo.cbL)  <<'\n';
         cbStr.flush();
     };
 

--- a/source/SoloReadBarcode.h
+++ b/source/SoloReadBarcode.h
@@ -8,7 +8,8 @@ class SoloReadBarcode {
 public:
     uint32 homoPolymer[4];//homopolymer constants
     string cbSeq, umiSeq, cbQual, umiQual;
-    uint32 cbB,umiB;
+    uint64 cbB;
+    uint32 umiB;
     int32  cbI;
     int32  cbMatch;//0=exact, 1=1 match with 1MM, 2= >1 matches with 1MM
     string cbMatchString;//CB matches and qualities

--- a/source/SoloReadBarcode_getCBandUMI.cpp
+++ b/source/SoloReadBarcode_getCBandUMI.cpp
@@ -20,7 +20,7 @@ void SoloReadBarcode::getCBandUMI(string &readNameExtra)
 
     //check UMIs, return if bad UMIs
     if (convertNuclStrToInt32(umiSeq,umiB)!=-1) {//convert and check for Ns
-        stats.V[stats.nNinBarcode]++;//UMIs are not allowed to have MMs
+        stats.V[stats.nNinBarcode]++;//UMIs are not allowed to have Ns
         return;
     };
     if (umiB==homoPolymer[0] || umiB==homoPolymer[1] || umiB==homoPolymer[2] || umiB==homoPolymer[3]) {
@@ -29,11 +29,11 @@ void SoloReadBarcode::getCBandUMI(string &readNameExtra)
     };
 
     //convert CB and check for Ns
-    int32 posN=convertNuclStrToInt32(cbSeq,cbB);
+    int64 posN=convertNuclStrToInt64(cbSeq,cbB);
     if (posN==-2) {//>2 Ns, might already be filtered by Illumina
         stats.V[stats.nNinBarcode]++;
         return;
-    } else if (posN==-1) {//no Ns, count only for feattureType==gene
+    } else if (posN==-1) {//no Ns, count only for featureType==gene
         cbI=binarySearchExact(cbB,pSolo.cbWL.data(),pSolo.cbWL.size());
         if (cbI>=0) {//exact match
             cbReadCountExact[cbI]++;//note that this simply counts reads per exact CB, no checks of genes or UMIs
@@ -45,7 +45,7 @@ void SoloReadBarcode::getCBandUMI(string &readNameExtra)
     if (posN>=0) {//one N
         uint32 posNshift=2*(pSolo.cbL-1-posN);//shift bits for posN
         for (uint32 jj=0; jj<4; jj++) {
-            uint32 cbB1=cbB^(jj<<posNshift);
+            uint64 cbB1=cbB^(jj<<posNshift);
             int32 cbI1=binarySearchExact(cbB1,pSolo.cbWL.data(),pSolo.cbWL.size());
             if (cbI1>=0) {
                 if (cbI>=0) {//had another match already


### PR DESCRIPTION
Add support for cell barcodes which are longer than 16 nucleotides.
The old code overwrote the first nucleotides of the cell barcodes
with As for position 1 till (length cell barcode - 16) as cell
barcodes where converted with "convertNuclStrToInt32" and converted
back to "convertNuclInt32toString" and this would cause an overflow.

The number of barcodes is still limited to 2^32 after this patch.
UMIs are still limited to 16 nucleotides. Longer UMIs could be
supported in a similar way.