### PR TITLE
Allow same tag for "--sjdbGTFtagExonParentTranscript" and "--sjdbGTFt…

### DIFF
--- a/source/loadGTF.cpp
+++ b/source/loadGTF.cpp
@@ -121,12 +121,12 @@ uint64 loadGTF(SjdbClass &sjdbLoci, Parameters &P, string dirOut, Genome &mapGen
             while (oneLineStream.good()) {
                 string attrName1("");
                 oneLineStream >> attrName1;
+                string attr1;
+                oneLineStream >> attr1;
+                attr1.erase(remove(attr1.begin(),attr1.end(),'"'),attr1.end());
+                attr1.erase(remove(attr1.begin(),attr1.end(),';'),attr1.end());
                 for (uint32 ii=0; ii<exAttrNames.size(); ii++) {
                     if (attrName1==exAttrNames[ii]) {
-                        string attr1;
-                        oneLineStream >> attr1;
-                        attr1.erase(remove(attr1.begin(),attr1.end(),'"'),attr1.end());
-                        attr1.erase(remove(attr1.begin(),attr1.end(),';'),attr1.end());
                         exAttr[ii]=attr1;
                     };
                 };


### PR DESCRIPTION
…agExonParentGene".

Allow to specify same tag for "--sjdbGTFtagExonParentTranscript" and
"--sjdbGTFtagExonParentGene" when reading a GTF file.

Before this patch, if both options had the same tag.

In case of STAR solo:
  - "*.Solo.out/genes.tsv" would be empty
  - "*.Solo.out/matrix.mtx" assigns all counted reads to the first
    "gene" instead of the correct one.

Supporting this feature makes is a bit easier to use STAR to use
regions as genes:

    chr1    regions_test    Region  1000       2000        .       .       .       region "chr1:1000-2000";
    chr2    regions_test    Region  3000       4000        .       .       .       region "chr2:3000-4000";

With the old code the fake GTF file needed to look like this:

    chr1    regions_test    Region  1000       2000        .       .       .       region_gene "chr1:1000-2000"; region_transcript "chr1:1000-2000";
    chr2    regions_test    Region  3000       4000        .       .       .       region_gene "chr2:3000-4000"; region_transcript "chr2:3000-4000";