### PR TITLE
Replace sub-second sleep with usleep.

### DIFF
--- a/source/STAR.cpp
+++ b/source/STAR.cpp
@@ -444,7 +444,7 @@ int main(int argInN, char* argIn[]) {
                             boolWait=false;
                             totalMem+=newMem;
                         };
-                        sleep(0.1);
+                        usleep(100000);
                     };
                     BAMbinSortByCoordinate(ibin,binN,binS,P.runThreadN,P.outBAMsortTmpDir, P, mainGenome);
                     #pragma omp critical


### PR DESCRIPTION
Sleep takes an integer, so 0.1 rounds down to 0. Replacing it with an usleep for 100000 µs should _actually_ sleep for 0.1s. 
(With thanks to clang for having readable warnings.)