### PR TITLE
chimeric alignment updates

### DIFF
--- a/source/ChimericAlign.h
+++ b/source/ChimericAlign.h
@@ -23,7 +23,7 @@ class ChimericAlign
         int chimMotif, chimStr, chimScore;
 
         ChimericAlign(ChimericSegment &seg1in, ChimericSegment &seg2in, int chimScoreIn, Genome &genomeIn, ReadAlign *RAin); //allocate
-        void chimericJunctionOutput(fstream &outStream, uint chimN, int maxNonChimAlignScore, bool PEmerged_flag, int chimScoreBest);
+        void chimericJunctionOutput(fstream &outStream, uint chimN, int maxNonChimAlignScore, bool PEmerged_flag, int chimScoreBest, int maxPossibleAlignScore);
         void chimericStitching(char *genSeq, char *readSeq);
         bool chimericCheck();
 

--- a/source/ChimericAlign.h
+++ b/source/ChimericAlign.h
@@ -23,7 +23,7 @@ class ChimericAlign
         int chimMotif, chimStr, chimScore;
 
         ChimericAlign(ChimericSegment &seg1in, ChimericSegment &seg2in, int chimScoreIn, Genome &genomeIn, ReadAlign *RAin); //allocate
-        void chimericJunctionOutput(fstream &outStream, uint chimN);
+        void chimericJunctionOutput(fstream &outStream, uint chimN, int maxNonChimAlignScore);
         void chimericStitching(char *genSeq, char *readSeq);
         bool chimericCheck();
 

--- a/source/ChimericAlign.h
+++ b/source/ChimericAlign.h
@@ -23,7 +23,7 @@ class ChimericAlign
         int chimMotif, chimStr, chimScore;
 
         ChimericAlign(ChimericSegment &seg1in, ChimericSegment &seg2in, int chimScoreIn, Genome &genomeIn, ReadAlign *RAin); //allocate
-        void chimericJunctionOutput(fstream &outStream, uint chimN, int maxNonChimAlignScore, bool PEmerged_flag);
+        void chimericJunctionOutput(fstream &outStream, uint chimN, int maxNonChimAlignScore, bool PEmerged_flag, int chimScoreBest);
         void chimericStitching(char *genSeq, char *readSeq);
         bool chimericCheck();
 

--- a/source/ChimericAlign.h
+++ b/source/ChimericAlign.h
@@ -23,7 +23,7 @@ class ChimericAlign
         int chimMotif, chimStr, chimScore;
 
         ChimericAlign(ChimericSegment &seg1in, ChimericSegment &seg2in, int chimScoreIn, Genome &genomeIn, ReadAlign *RAin); //allocate
-        void chimericJunctionOutput(fstream &outStream, uint chimN, int maxNonChimAlignScore);
+        void chimericJunctionOutput(fstream &outStream, uint chimN, int maxNonChimAlignScore, bool PEmerged_flag);
         void chimericStitching(char *genSeq, char *readSeq);
         bool chimericCheck();
 

--- a/source/ChimericAlign.h
+++ b/source/ChimericAlign.h
@@ -24,7 +24,7 @@ class ChimericAlign
 
         ChimericAlign(ChimericSegment &seg1in, ChimericSegment &seg2in, int chimScoreIn, Genome &genomeIn, ReadAlign *RAin); //allocate
         void chimericJunctionOutput(fstream &outStream, uint chimN, int maxNonChimAlignScore, bool PEmerged_flag, int chimScoreBest, int maxPossibleAlignScore);
-        void chimericStitching(char *genSeq, char *readSeq);
+        void chimericStitching(char *genSeq, char **Read1);
         bool chimericCheck();
 
         bool stitchingDone;

--- a/source/ChimericAlign_chimericJunctionOutput.cpp
+++ b/source/ChimericAlign_chimericJunctionOutput.cpp
@@ -10,7 +10,7 @@ void ChimericAlign::chimericJunctionOutput(fstream &outStream, uint chimN, int m
         <<"\t"<< al2->exons[0][EX_G] - mapGen.chrStart[al2->Chr]+1 <<"\t"<< al2->generateCigarP() <<"\t"<< chimN
         << "\t" << maxNonChimAlignScore
         << "\t" << chimScore
-        << "\t" << PEmerged;
+        << "\t" << PEmerged_flag;
 
         if (P.outSAMattrPresent.RG)
             outStream <<"\t"<< P.outSAMattrRG.at(RA->readFilesIndex);

--- a/source/ChimericAlign_chimericJunctionOutput.cpp
+++ b/source/ChimericAlign_chimericJunctionOutput.cpp
@@ -1,13 +1,16 @@
 #include "ChimericAlign.h"
 #include "ReadAlign.h"
 
-void ChimericAlign::chimericJunctionOutput(fstream &outStream, uint chimN)
+void ChimericAlign::chimericJunctionOutput(fstream &outStream, uint chimN, int maxNonChimAlignScore)
 {
     outStream << mapGen.chrName[al1->Chr] <<"\t"<< chimJ1 - mapGen.chrStart[al1->Chr]+1 <<"\t"<< (al1->Str==0 ? "+":"-") \
         <<"\t"<< mapGen.chrName[al2->Chr] <<"\t"<< chimJ2 - mapGen.chrStart[al2->Chr]+1 <<"\t"<< (al2->Str==0 ? "+":"-") \
         <<"\t"<< chimMotif <<"\t"<< chimRepeat1  <<"\t"<< chimRepeat2 <<"\t"<< al1->readName+1 \
         <<"\t"<< al1->exons[0][EX_G] - mapGen.chrStart[al1->Chr]+1 <<"\t"<< al1->generateCigarP() \
-        <<"\t"<< al2->exons[0][EX_G] - mapGen.chrStart[al2->Chr]+1 <<"\t"<< al2->generateCigarP() <<"\t"<< chimN;
+        <<"\t"<< al2->exons[0][EX_G] - mapGen.chrStart[al2->Chr]+1 <<"\t"<< al2->generateCigarP() <<"\t"<< chimN
+        << "\t" << maxNonChimAlignScore
+        << "\t" << chimScore;
+        
         if (P.outSAMattrPresent.RG)
             outStream <<"\t"<< P.outSAMattrRG.at(RA->readFilesIndex);
         if (P.pSolo.type>0)

--- a/source/ChimericAlign_chimericJunctionOutput.cpp
+++ b/source/ChimericAlign_chimericJunctionOutput.cpp
@@ -10,6 +10,7 @@ void ChimericAlign::chimericJunctionOutput(fstream &outStream, uint chimN, int m
         <<"\t"<< al2->exons[0][EX_G] - mapGen.chrStart[al2->Chr]+1 <<"\t"<< al2->generateCigarP() <<"\t"<< chimN
         << "\t" << maxNonChimAlignScore
         << "\t" << chimScore
+        << "\t" << chimScoreBest
         << "\t" << PEmerged_flag;
 
         if (P.outSAMattrPresent.RG)

--- a/source/ChimericAlign_chimericJunctionOutput.cpp
+++ b/source/ChimericAlign_chimericJunctionOutput.cpp
@@ -1,7 +1,7 @@
 #include "ChimericAlign.h"
 #include "ReadAlign.h"
 
-void ChimericAlign::chimericJunctionOutput(fstream &outStream, uint chimN, int maxNonChimAlignScore)
+void ChimericAlign::chimericJunctionOutput(fstream &outStream, uint chimN, int maxNonChimAlignScore, bool PEmerged_flag)
 {
     outStream << mapGen.chrName[al1->Chr] <<"\t"<< chimJ1 - mapGen.chrStart[al1->Chr]+1 <<"\t"<< (al1->Str==0 ? "+":"-") \
         <<"\t"<< mapGen.chrName[al2->Chr] <<"\t"<< chimJ2 - mapGen.chrStart[al2->Chr]+1 <<"\t"<< (al2->Str==0 ? "+":"-") \
@@ -9,8 +9,9 @@ void ChimericAlign::chimericJunctionOutput(fstream &outStream, uint chimN, int m
         <<"\t"<< al1->exons[0][EX_G] - mapGen.chrStart[al1->Chr]+1 <<"\t"<< al1->generateCigarP() \
         <<"\t"<< al2->exons[0][EX_G] - mapGen.chrStart[al2->Chr]+1 <<"\t"<< al2->generateCigarP() <<"\t"<< chimN
         << "\t" << maxNonChimAlignScore
-        << "\t" << chimScore;
-        
+        << "\t" << chimScore
+        << "\t" << PEmerged;
+
         if (P.outSAMattrPresent.RG)
             outStream <<"\t"<< P.outSAMattrRG.at(RA->readFilesIndex);
         if (P.pSolo.type>0)

--- a/source/ChimericAlign_chimericJunctionOutput.cpp
+++ b/source/ChimericAlign_chimericJunctionOutput.cpp
@@ -1,7 +1,7 @@
 #include "ChimericAlign.h"
 #include "ReadAlign.h"
 
-void ChimericAlign::chimericJunctionOutput(fstream &outStream, uint chimN, int maxNonChimAlignScore, bool PEmerged_flag)
+void ChimericAlign::chimericJunctionOutput(fstream &outStream, uint chimN, int maxNonChimAlignScore, bool PEmerged_flag, int chimScoreBest)
 {
     outStream << mapGen.chrName[al1->Chr] <<"\t"<< chimJ1 - mapGen.chrStart[al1->Chr]+1 <<"\t"<< (al1->Str==0 ? "+":"-") \
         <<"\t"<< mapGen.chrName[al2->Chr] <<"\t"<< chimJ2 - mapGen.chrStart[al2->Chr]+1 <<"\t"<< (al2->Str==0 ? "+":"-") \

--- a/source/ChimericAlign_chimericJunctionOutput.cpp
+++ b/source/ChimericAlign_chimericJunctionOutput.cpp
@@ -1,17 +1,19 @@
 #include "ChimericAlign.h"
 #include "ReadAlign.h"
 
-void ChimericAlign::chimericJunctionOutput(fstream &outStream, uint chimN, int maxNonChimAlignScore, bool PEmerged_flag, int chimScoreBest)
+void ChimericAlign::chimericJunctionOutput(fstream &outStream, uint chimN, int maxNonChimAlignScore, bool PEmerged_flag, int chimScoreBest, int maxPossibleAlignScore)
 {
     outStream << mapGen.chrName[al1->Chr] <<"\t"<< chimJ1 - mapGen.chrStart[al1->Chr]+1 <<"\t"<< (al1->Str==0 ? "+":"-") \
         <<"\t"<< mapGen.chrName[al2->Chr] <<"\t"<< chimJ2 - mapGen.chrStart[al2->Chr]+1 <<"\t"<< (al2->Str==0 ? "+":"-") \
         <<"\t"<< chimMotif <<"\t"<< chimRepeat1  <<"\t"<< chimRepeat2 <<"\t"<< al1->readName+1 \
         <<"\t"<< al1->exons[0][EX_G] - mapGen.chrStart[al1->Chr]+1 <<"\t"<< al1->generateCigarP() \
-        <<"\t"<< al2->exons[0][EX_G] - mapGen.chrStart[al2->Chr]+1 <<"\t"<< al2->generateCigarP() <<"\t"<< chimN
-        << "\t" << maxNonChimAlignScore
-        << "\t" << chimScore
-        << "\t" << chimScoreBest
-        << "\t" << PEmerged_flag;
+        <<"\t"<< al2->exons[0][EX_G] - mapGen.chrStart[al2->Chr]+1 <<"\t"<< al2->generateCigarP()
+        <<"\t"<< chimN // number of multimapping chimeric alignments for this read.
+        << "\t" << maxPossibleAlignScore  // the maximum possible alignment score (currently the sum of the (paired) read lengths)
+        << "\t" << maxNonChimAlignScore // trBest - the best alignment score from a non-chimeric alignment of this read to the ref genome.
+        << "\t" << chimScore    // current chimeric alignment score
+        << "\t" << chimScoreBest  // best chimeric score among multimapping chimeric alignments.
+        << "\t" << PEmerged_flag;  // boolean indicating paired reads were merged into a single read before alignment & chimer detection.
 
         if (P.outSAMattrPresent.RG)
             outStream <<"\t"<< P.outSAMattrRG.at(RA->readFilesIndex);

--- a/source/ChimericAlign_chimericStitching.cpp
+++ b/source/ChimericAlign_chimericStitching.cpp
@@ -1,11 +1,13 @@
 #include "ChimericAlign.h"
 
-void ChimericAlign::chimericStitching(char *genSeq, char *readSeq) {
+void ChimericAlign::chimericStitching(char *genSeq, char **Read1) {
 
     if (stitchingDone)
         return;
 
     stitchingDone=true;
+
+    char *readSeq=Read1[0]; //only direct read sequence is used - reverse complemented if necessary in the algorithm
 
     al1=new Transcript(*al1);
     al2=new Transcript(*al2);
@@ -168,9 +170,12 @@ void ChimericAlign::chimericStitching(char *genSeq, char *readSeq) {
         chimRepeat1=jR;
     };//chimeric junction is within a mate
 
-    if (chimMotif>=0 && (a1.exons[ex1][EX_L]<P.pCh.junctionOverhangMin+chimRepeat1 || a2.exons[ex2][EX_L]<P.pCh.junctionOverhangMin+chimRepeat2) ) {
+    if (chimMotif>=0 && (a1.exons[ex1][EX_L]<P.pCh.junctionOverhangMin || a2.exons[ex2][EX_L]<P.pCh.junctionOverhangMin) ) {
         //filter out cases where linear junctions that are very close to chimeric junction
         chimScore=0;
         return;
     };
+
+    //re-calculate chimScore for adjusted transcripts
+    chimScore=a1.alignScore(Read1,genSeq,P) + a2.alignScore(Read1,genSeq,P) + (chimMotif==0 ? P.pCh.scoreJunctionNonGTAG : 0);
 };

--- a/source/ChimericDetection.h
+++ b/source/ChimericDetection.h
@@ -26,7 +26,7 @@ class ChimericDetection {
         int chimScoreBest;
 
         ChimericDetection(Parameters &Pin, Transcript ***trAll, uint *nWinTr, char** Read1in, Genome &genomeIn, fstream *ostreamChimJunctionIn, ReadAlign *RA);
-        bool chimericDetectionMult(uint nWin, uint *readLengthIn, int maxNonChimAlignScore);
+        bool chimericDetectionMult(uint nWin, uint *readLengthIn, int maxNonChimAlignScore, bool PEmerged_flag);
         fstream *ostreamChimJunction;
 };
 

--- a/source/ChimericDetection.h
+++ b/source/ChimericDetection.h
@@ -26,7 +26,7 @@ class ChimericDetection {
         int chimScoreBest;
 
         ChimericDetection(Parameters &Pin, Transcript ***trAll, uint *nWinTr, char** Read1in, Genome &genomeIn, fstream *ostreamChimJunctionIn, ReadAlign *RA);
-        bool chimericDetectionMult(uint nWin, uint *readLengthIn, int maxNonChimAlignScore, bool PEmerged_flag);
+        bool chimericDetectionMult(uint nWin, uint *readLengthIn, int maxNonChimAlignScore, bool PEmerged_flag, int maxPossibleAlignScore);
         fstream *ostreamChimJunction;
 };
 

--- a/source/ChimericDetection.h
+++ b/source/ChimericDetection.h
@@ -26,7 +26,7 @@ class ChimericDetection {
         int chimScoreBest;
 
         ChimericDetection(Parameters &Pin, Transcript ***trAll, uint *nWinTr, char** Read1in, Genome &genomeIn, fstream *ostreamChimJunctionIn, ReadAlign *RA);
-        bool chimericDetectionMult(uint nWin, uint *readLengthIn);
+        bool chimericDetectionMult(uint nWin, uint *readLengthIn, int maxNonChimAlignScore);
         fstream *ostreamChimJunction;
 };
 

--- a/source/ChimericDetection.h
+++ b/source/ChimericDetection.h
@@ -26,7 +26,7 @@ class ChimericDetection {
         int chimScoreBest;
 
         ChimericDetection(Parameters &Pin, Transcript ***trAll, uint *nWinTr, char** Read1in, Genome &genomeIn, fstream *ostreamChimJunctionIn, ReadAlign *RA);
-        bool chimericDetectionMult(uint nWin, uint *readLengthIn, int maxNonChimAlignScore, bool PEmerged_flag, int maxPossibleAlignScore);
+        bool chimericDetectionMult(uint nWin, uint *readLengthIn, int maxNonChimAlignScore, bool PEmerged_flag);
         fstream *ostreamChimJunction;
 };
 

--- a/source/ChimericDetection_chimericDetectionMult.cpp
+++ b/source/ChimericDetection_chimericDetectionMult.cpp
@@ -78,12 +78,10 @@ bool ChimericDetection::chimericDetectionMult(uint nW, uint *readLength, int max
                         if (!chAl.chimericCheck())
                             continue; //check chimeric alignment
 
-                        chAl.chimericStitching(outGen.G, Read1[0]);
+                        //re-calculated chimScoreBest includes non-canonical penalty, so the re-calculated score is lower, in some cases it goes to 0 if some checks are not passed
+                        chAl.chimericStitching(outGen.G, Read1);
                         // rescore after stitching.
                         if (chAl.chimScore > maxNonChimAlignScore) { // survived stitching.
-                            // rescore the stitched alignment.
-                            chimScore=chimericAlignScore(chAl.seg1,chAl.seg2);
-                            chAl.chimScore = chimScore;
                             chimAligns.push_back(chAl);//add this chimeric alignment
 
                             if (chimAligns.back().chimScore > chimScoreBest)
@@ -100,7 +98,8 @@ bool ChimericDetection::chimericDetectionMult(uint nW, uint *readLength, int max
         return chimRecord;
 
     chimN=0;
-    for (auto cAit=chimAligns.begin(); cAit<chimAligns.end(); cAit++) {//scan all chimeras, find the number within score range
+    for (auto cAit=chimAligns.begin(); cAit<chimAligns.end(); cAit++) {
+        //scan all chimeras, find the number within score range
         if (cAit->chimScore >= chimScoreBest - (int)P.pCh.multimapScoreRange)
             ++chimN;
     };

--- a/source/ChimericDetection_chimericDetectionMult.cpp
+++ b/source/ChimericDetection_chimericDetectionMult.cpp
@@ -19,7 +19,7 @@ int chimericAlignScore (ChimericSegment & seg1, ChimericSegment & seg2)
 };
 
 /////////////////////////////////////////////////////////////
-bool ChimericDetection::chimericDetectionMult(uint nW, uint *readLength) {
+bool ChimericDetection::chimericDetectionMult(uint nW, uint *readLength, int maxNonChimAlignScore) {
 
     chimRecord=false;
 
@@ -39,8 +39,6 @@ bool ChimericDetection::chimericDetectionMult(uint nW, uint *readLength) {
 
     chimAligns.clear();
     chimScoreBest=0;
-
-    int bestNonchimAlignScore = RA->trBest->maxScore;
 
     for (uint iW1=0; iW1<nW; iW1++) {//cycle windows
         for (uint iA1=0; iA1<nWinTr[iW1]; iA1++) {//cycle aligns in the window

--- a/source/ChimericDetection_chimericDetectionMult.cpp
+++ b/source/ChimericDetection_chimericDetectionMult.cpp
@@ -75,9 +75,9 @@ bool ChimericDetection::chimericDetectionMult(uint nW, uint *readLength, int max
                             if (chimScore >= P.pCh.scoreMin && chimScore >= (int)(readLength[0]+readLength[1]) - P.pCh.scoreDropMax ) {
                                 // rescore after stitching.
                                 chimScore=chimericAlignScore(chAl.seg1,chAl.seg2);
-                                chAl.chimScore = chimScore
+                                chAl.chimScore = chimScore;
                                 chimAligns.push_back(chAl);//add this chimeric alignment
-                                
+
                                 if (chimAligns.back().chimScore > chimScoreBest)
                                     chimScoreBest=chimAligns.back().chimScore;
                             }; // endif add chimeric alignment vector

--- a/source/ChimericDetection_chimericDetectionMult.cpp
+++ b/source/ChimericDetection_chimericDetectionMult.cpp
@@ -19,7 +19,7 @@ int chimericAlignScore (ChimericSegment & seg1, ChimericSegment & seg2)
 };
 
 /////////////////////////////////////////////////////////////
-bool ChimericDetection::chimericDetectionMult(uint nW, uint *readLength, int maxNonChimAlignScore, bool PEmerged_flag, int maxPossibleAlignScore) {
+bool ChimericDetection::chimericDetectionMult(uint nW, uint *readLength, int maxNonChimAlignScore, bool PEmerged_flag) {
 
     chimRecord=false;
 
@@ -39,6 +39,8 @@ bool ChimericDetection::chimericDetectionMult(uint nW, uint *readLength, int max
 
     chimAligns.clear();
     chimScoreBest=0;
+
+    int maxPossibleAlignScore = (int)(readLength[0]+readLength[1])
 
     for (uint iW1=0; iW1<nW; iW1++) {//cycle windows
         for (uint iA1=0; iA1<nWinTr[iW1]; iA1++) {//cycle aligns in the window
@@ -64,7 +66,7 @@ bool ChimericDetection::chimericDetectionMult(uint nW, uint *readLength, int max
 
                     if (chimScore > maxNonChimAlignScore
                           &&
-                        chimScore >= (int)(readLength[0]+readLength[1]) - P.pCh.scoreDropMax
+                        chimScore >= maxPossibleAlignScore - P.pCh.scoreDropMax
                           &&
                         chimScore >= P.pCh.scoreMin
                           &&

--- a/source/ChimericDetection_chimericDetectionMult.cpp
+++ b/source/ChimericDetection_chimericDetectionMult.cpp
@@ -12,7 +12,10 @@ int chimericAlignScore (ChimericSegment & seg1, ChimericSegment & seg2)
     if (seg1.roE > seg1.P.pCh.segmentMin + seg1.roS + chimOverlap && seg2.roE > seg1.P.pCh.segmentMin + seg2.roS + chimOverlap  \
         && ( diffMates || ( (seg1.roE + seg1.P.pCh.segmentReadGapMax + 1) >= seg2.roS && (seg2.roE + seg1.P.pCh.segmentReadGapMax + 1) >= seg1.roS ) ) )
     {
-       chimScore = seg1.align.maxScore + seg2.align.maxScore - (int)chimOverlap; //subtract overlap to avoid double counting
+       //chimScore = seg1.align.maxScore + seg2.align.maxScore - (int)chimOverlap; //subtract overlap to avoid double counting
+
+       chimScore = seg1.align.maxScore + seg2.align.maxScore;  // need to double count overlapping bases since all other scores are also containing the overlapping bases.
+       
     };
 
     return chimScore;

--- a/source/ChimericDetection_chimericDetectionMult.cpp
+++ b/source/ChimericDetection_chimericDetectionMult.cpp
@@ -62,7 +62,7 @@ bool ChimericDetection::chimericDetectionMult(uint nW, uint *readLength, int max
 
                     int chimScore=chimericAlignScore(seg1,seg2);
 
-                    if (chimScore>0
+                    if (chimScore > maxNonChimAlignScore
                           &&
                         chimScore >= (int)(readLength[0]+readLength[1]) - P.pCh.scoreDropMax
                           &&
@@ -78,7 +78,8 @@ bool ChimericDetection::chimericDetectionMult(uint nW, uint *readLength, int max
 
                         chAl.chimericStitching(outGen.G, Read1[0]);
                         // rescore after stitching.
-                        if (chAl.chimScore > 0) { // survived stitching.
+                        if (chAl.chimScore > maxNonChimAlignScore) { // survived stitching.
+                            // rescore the stitched alignment.
                             chimScore=chimericAlignScore(chAl.seg1,chAl.seg2);
                             chAl.chimScore = chimScore;
                             chimAligns.push_back(chAl);//add this chimeric alignment
@@ -101,6 +102,8 @@ bool ChimericDetection::chimericDetectionMult(uint nW, uint *readLength, int max
         if (cAit->chimScore >= chimScoreBest - (int)P.pCh.multimapScoreRange)
             ++chimN;
     };
+
+    /*
     if (chimN > 2*P.pCh.multimapNmax) //too many loci (considering 2* more candidates for stitching below)
         return chimRecord;
 
@@ -112,6 +115,8 @@ bool ChimericDetection::chimericDetectionMult(uint nW, uint *readLength, int max
                 ++chimN;
         };
     };
+    */
+
     if (chimN > P.pCh.multimapNmax) //too many loci
         return chimRecord;
 

--- a/source/ChimericDetection_chimericDetectionMult.cpp
+++ b/source/ChimericDetection_chimericDetectionMult.cpp
@@ -40,8 +40,8 @@ bool ChimericDetection::chimericDetectionMult(uint nW, uint *readLength) {
     chimAligns.clear();
     chimScoreBest=0;
 
-    int bestNonchimAlignScore = trBest->maxScore;
-    
+    int bestNonchimAlignScore = RA->trBest->maxScore;
+
     for (uint iW1=0; iW1<nW; iW1++) {//cycle windows
         for (uint iA1=0; iA1<nWinTr[iW1]; iA1++) {//cycle aligns in the window
 

--- a/source/ChimericDetection_chimericDetectionMult.cpp
+++ b/source/ChimericDetection_chimericDetectionMult.cpp
@@ -108,7 +108,7 @@ bool ChimericDetection::chimericDetectionMult(uint nW, uint *readLength, int max
 
     for (auto cAit=chimAligns.begin(); cAit<chimAligns.end(); cAit++) {//output chimeras within score range
         if (cAit->chimScore >= chimScoreBest-(int)P.pCh.multimapScoreRange)
-            cAit->chimericJunctionOutput(*ostreamChimJunction, chimN, maxNonChimAlignScore, PEmerged_flag);
+            cAit->chimericJunctionOutput(*ostreamChimJunction, chimN, maxNonChimAlignScore, PEmerged_flag, chimScoreBest);
     };
 
     if (chimN>0)

--- a/source/ChimericDetection_chimericDetectionMult.cpp
+++ b/source/ChimericDetection_chimericDetectionMult.cpp
@@ -19,7 +19,7 @@ int chimericAlignScore (ChimericSegment & seg1, ChimericSegment & seg2)
 };
 
 /////////////////////////////////////////////////////////////
-bool ChimericDetection::chimericDetectionMult(uint nW, uint *readLength, int maxNonChimAlignScore, bool PEmerged_flag) {
+bool ChimericDetection::chimericDetectionMult(uint nW, uint *readLength, int maxNonChimAlignScore, bool PEmerged_flag, int maxPossibleAlignScore) {
 
     chimRecord=false;
 
@@ -108,7 +108,7 @@ bool ChimericDetection::chimericDetectionMult(uint nW, uint *readLength, int max
 
     for (auto cAit=chimAligns.begin(); cAit<chimAligns.end(); cAit++) {//output chimeras within score range
         if (cAit->chimScore >= chimScoreBest-(int)P.pCh.multimapScoreRange)
-            cAit->chimericJunctionOutput(*ostreamChimJunction, chimN, maxNonChimAlignScore, PEmerged_flag, chimScoreBest);
+            cAit->chimericJunctionOutput(*ostreamChimJunction, chimN, maxNonChimAlignScore, PEmerged_flag, chimScoreBest, maxPossibleAlignScore);
     };
 
     if (chimN>0)

--- a/source/ChimericDetection_chimericDetectionMult.cpp
+++ b/source/ChimericDetection_chimericDetectionMult.cpp
@@ -40,7 +40,7 @@ bool ChimericDetection::chimericDetectionMult(uint nW, uint *readLength, int max
     chimAligns.clear();
     chimScoreBest=0;
 
-    int maxPossibleAlignScore = (int)(readLength[0]+readLength[1])
+    int maxPossibleAlignScore = (int)(readLength[0]+readLength[1]);
 
     for (uint iW1=0; iW1<nW; iW1++) {//cycle windows
         for (uint iA1=0; iA1<nWinTr[iW1]; iA1++) {//cycle aligns in the window

--- a/source/ChimericDetection_chimericDetectionMult.cpp
+++ b/source/ChimericDetection_chimericDetectionMult.cpp
@@ -108,7 +108,7 @@ bool ChimericDetection::chimericDetectionMult(uint nW, uint *readLength, int max
 
     for (auto cAit=chimAligns.begin(); cAit<chimAligns.end(); cAit++) {//output chimeras within score range
         if (cAit->chimScore >= chimScoreBest-(int)P.pCh.multimapScoreRange)
-            cAit->chimericJunctionOutput(*ostreamChimJunction, chimN);
+            cAit->chimericJunctionOutput(*ostreamChimJunction, chimN, maxNonChimAlignScore);
     };
 
     if (chimN>0)

--- a/source/ChimericDetection_chimericDetectionMult.cpp
+++ b/source/ChimericDetection_chimericDetectionMult.cpp
@@ -19,7 +19,7 @@ int chimericAlignScore (ChimericSegment & seg1, ChimericSegment & seg2)
 };
 
 /////////////////////////////////////////////////////////////
-bool ChimericDetection::chimericDetectionMult(uint nW, uint *readLength, int maxNonChimAlignScore) {
+bool ChimericDetection::chimericDetectionMult(uint nW, uint *readLength, int maxNonChimAlignScore, bool PEmerged_flag) {
 
     chimRecord=false;
 
@@ -108,7 +108,7 @@ bool ChimericDetection::chimericDetectionMult(uint nW, uint *readLength, int max
 
     for (auto cAit=chimAligns.begin(); cAit<chimAligns.end(); cAit++) {//output chimeras within score range
         if (cAit->chimScore >= chimScoreBest-(int)P.pCh.multimapScoreRange)
-            cAit->chimericJunctionOutput(*ostreamChimJunction, chimN, maxNonChimAlignScore);
+            cAit->chimericJunctionOutput(*ostreamChimJunction, chimN, maxNonChimAlignScore, PEmerged_flag);
     };
 
     if (chimN>0)

--- a/source/ChimericDetection_chimericDetectionMult.cpp
+++ b/source/ChimericDetection_chimericDetectionMult.cpp
@@ -40,6 +40,8 @@ bool ChimericDetection::chimericDetectionMult(uint nW, uint *readLength) {
     chimAligns.clear();
     chimScoreBest=0;
 
+    int bestNonchimAlignScore = trBest->maxScore;
+    
     for (uint iW1=0; iW1<nW; iW1++) {//cycle windows
         for (uint iA1=0; iA1<nWinTr[iW1]; iA1++) {//cycle aligns in the window
 

--- a/source/ReadAlign_chimericDetection.cpp
+++ b/source/ReadAlign_chimericDetection.cpp
@@ -46,7 +46,7 @@ void ReadAlign::chimericDetection() {
         chimRecord=chimericDetectionOld();
         chimericDetectionOldOutput();
     } else if (trBest->maxScore <= (int) (readLength[0]+readLength[1]) - (int) P.pCh.nonchimScoreDropMin) {//require big enough drop in the best score
-        chimRecord=chimDet->chimericDetectionMult(nW, readLength);
+        chimRecord=chimDet->chimericDetectionMult(nW, readLength, trBest->maxScore);
     };
 
     if ( chimRecord ) {

--- a/source/ReadAlign_chimericDetection.cpp
+++ b/source/ReadAlign_chimericDetection.cpp
@@ -46,7 +46,7 @@ void ReadAlign::chimericDetection() {
         chimRecord=chimericDetectionOld();
         chimericDetectionOldOutput();
     } else if (trBest->maxScore <= (int) (readLength[0]+readLength[1]) - (int) P.pCh.nonchimScoreDropMin) {//require big enough drop in the best score
-        chimRecord=chimDet->chimericDetectionMult(nW, readLength, trBest->maxScore);
+        chimRecord=chimDet->chimericDetectionMult(nW, readLength, trBest->maxScore, false);
     };
 
     if ( chimRecord ) {

--- a/source/ReadAlign_chimericDetection.cpp
+++ b/source/ReadAlign_chimericDetection.cpp
@@ -46,7 +46,7 @@ void ReadAlign::chimericDetection() {
         chimRecord=chimericDetectionOld();
         chimericDetectionOldOutput();
     } else if (trBest->maxScore <= (int) (readLength[0]+readLength[1]) - (int) P.pCh.nonchimScoreDropMin) {//require big enough drop in the best score
-        chimRecord=chimDet->chimericDetectionMult(nW, readLength, trBest->maxScore, false, readLength[0]+readLength[1]);
+        chimRecord=chimDet->chimericDetectionMult(nW, readLength, trBest->maxScore, false);
     };
 
     if ( chimRecord ) {

--- a/source/ReadAlign_chimericDetection.cpp
+++ b/source/ReadAlign_chimericDetection.cpp
@@ -46,7 +46,7 @@ void ReadAlign::chimericDetection() {
         chimRecord=chimericDetectionOld();
         chimericDetectionOldOutput();
     } else if (trBest->maxScore <= (int) (readLength[0]+readLength[1]) - (int) P.pCh.nonchimScoreDropMin) {//require big enough drop in the best score
-        chimRecord=chimDet->chimericDetectionMult(nW, readLength, trBest->maxScore, false);
+        chimRecord=chimDet->chimericDetectionMult(nW, readLength, trBest->maxScore, false, readLength[0]+readLength[1]);
     };
 
     if ( chimRecord ) {

--- a/source/ReadAlign_chimericDetectionPEmerged.cpp
+++ b/source/ReadAlign_chimericDetectionPEmerged.cpp
@@ -10,6 +10,8 @@ void ReadAlign::chimericDetectionPEmerged(ReadAlign &seRA) {
 
     if (P.pCh.multimapNmax==0) {
 
+        // runs old chimeric detection routines.
+
         seRA.multMapSelect(); //this needs to be done for ChimericDetectionOld, may not need it for the new algorithm
         seRA.mappedFilter();
 
@@ -67,7 +69,10 @@ void ReadAlign::chimericDetectionPEmerged(ReadAlign &seRA) {
         chimericDetectionOldOutput();
 
     } else if (trBest->maxScore <= (int) (readLength[0]+readLength[1]) - (int) P.pCh.nonchimScoreDropMin) {//require big enough drop in the best score
-        chimRecord=seRA.chimDet->chimericDetectionMult(seRA.nW, seRA.readLength, trBest->maxScore, true);
+
+        // new chimeric detection routine
+
+        chimRecord=seRA.chimDet->chimericDetectionMult(seRA.nW, seRA.readLength, trBest->maxScore, true, readLength[0]+readLength[1]);
     };
 
     if ( chimRecord ) {

--- a/source/ReadAlign_chimericDetectionPEmerged.cpp
+++ b/source/ReadAlign_chimericDetectionPEmerged.cpp
@@ -72,7 +72,7 @@ void ReadAlign::chimericDetectionPEmerged(ReadAlign &seRA) {
 
         // new chimeric detection routine
 
-        chimRecord=seRA.chimDet->chimericDetectionMult(seRA.nW, seRA.readLength, trBest->maxScore, true);
+        chimRecord=seRA.chimDet->chimericDetectionMult(seRA.nW, seRA.readLength, seRA.trBest->maxScore, true);
     };
 
     if ( chimRecord ) {

--- a/source/ReadAlign_chimericDetectionPEmerged.cpp
+++ b/source/ReadAlign_chimericDetectionPEmerged.cpp
@@ -72,7 +72,7 @@ void ReadAlign::chimericDetectionPEmerged(ReadAlign &seRA) {
 
         // new chimeric detection routine
 
-        chimRecord=seRA.chimDet->chimericDetectionMult(seRA.nW, seRA.readLength, trBest->maxScore, true, readLength[0]+readLength[1]);
+        chimRecord=seRA.chimDet->chimericDetectionMult(seRA.nW, seRA.readLength, trBest->maxScore, true);
     };
 
     if ( chimRecord ) {

--- a/source/ReadAlign_chimericDetectionPEmerged.cpp
+++ b/source/ReadAlign_chimericDetectionPEmerged.cpp
@@ -67,7 +67,7 @@ void ReadAlign::chimericDetectionPEmerged(ReadAlign &seRA) {
         chimericDetectionOldOutput();
 
     } else if (trBest->maxScore <= (int) (readLength[0]+readLength[1]) - (int) P.pCh.nonchimScoreDropMin) {//require big enough drop in the best score
-        chimRecord=seRA.chimDet->chimericDetectionMult(seRA.nW, seRA.readLength);
+        chimRecord=seRA.chimDet->chimericDetectionMult(seRA.nW, seRA.readLength, trBest->maxScore);
     };
 
     if ( chimRecord ) {
@@ -76,4 +76,3 @@ void ReadAlign::chimericDetectionPEmerged(ReadAlign &seRA) {
 
     return;
 };
-

--- a/source/ReadAlign_chimericDetectionPEmerged.cpp
+++ b/source/ReadAlign_chimericDetectionPEmerged.cpp
@@ -67,7 +67,7 @@ void ReadAlign::chimericDetectionPEmerged(ReadAlign &seRA) {
         chimericDetectionOldOutput();
 
     } else if (trBest->maxScore <= (int) (readLength[0]+readLength[1]) - (int) P.pCh.nonchimScoreDropMin) {//require big enough drop in the best score
-        chimRecord=seRA.chimDet->chimericDetectionMult(seRA.nW, seRA.readLength, trBest->maxScore);
+        chimRecord=seRA.chimDet->chimericDetectionMult(seRA.nW, seRA.readLength, trBest->maxScore, true);
     };
 
     if ( chimRecord ) {

--- a/source/ReadAlign_mapOneRead.cpp
+++ b/source/ReadAlign_mapOneRead.cpp
@@ -15,6 +15,9 @@ int ReadAlign::mapOneRead() {
 
     if (Lread>0) {
         Nsplit=qualitySplit(Read1[0], Qual1[0], Lread, P.Qsplit, P.maxNsplit, P.minLsplit, splitR);
+        // splitR[0][fragnum] => good region start position   (from SequenceFuns.cpp)
+        // splitR[1][fragnum] => good reagion length
+        // splitR[2][fragnum] => fragnum ?
     } else {
         Nsplit=0;
     };
@@ -35,31 +38,38 @@ int ReadAlign::mapOneRead() {
 
     trBest=trInit;
 
-    uint seedSearchStartLmax=min(P.seedSearchStartLmax,(uint) (P.seedSearchStartLmaxOverLread*(Lread-1)));
+    uint seedSearchStartLmax=min(P.seedSearchStartLmax, // 50
+                                  (uint) (P.seedSearchStartLmaxOverLread*(Lread-1))); // read length
     // align all good pieces
     for (uint ip=0; ip<Nsplit; ip++) {
 
+
+        // if the good piece is long, then try multiple times to map it
         uint Nstart = P.seedSearchStartLmax>0 && seedSearchStartLmax<splitR[1][ip] ? splitR[1][ip]/seedSearchStartLmax+1 : 1;
-        uint Lstart = splitR[1][ip]/Nstart;
+        uint Lstart = splitR[1][ip]/Nstart;  // length of segment to map.
         bool flagDirMap=true;
-        for (uint iDir=0; iDir<2; iDir++) {//loop over two directions
+
+        for (uint iDir=0; iDir<2; iDir++) {//loop over two directions (leftToRight and RightToLeft)
 
             uint Lmapped, L;
 
-            for (uint istart=0; istart<Nstart; istart++) {
+            for (uint istart=0; istart<Nstart; istart++) {  // each try to map a segment.
 
 //               #ifdef COMPILE_FOR_LONG_READS
 //
 //               #else
                 if (flagDirMap || istart>0) {//check if the 1st piece in reveree direction does not need to be remapped
-                    Lmapped=0;
-                    while ( istart*Lstart + Lmapped + P.minLmap < splitR[1][ip] ) {//map until unmapped portion is <=minLmap
+                    Lmapped=0;  // length of segment mapped so far.
 
+                    // begin mapping starting from segment start position (istart*Lstart)
+                    while ( istart*Lstart + Lmapped + P.minLmap < splitR[1][ip] ) {//map until unmapped portion is <=minLmap (default: 5)
+
+                        // Shift is the position in the read to begin mapping from.
                         uint Shift = iDir==0 ? ( splitR[0][ip] + istart*Lstart + Lmapped ) : \
                                    ( splitR[0][ip] + splitR[1][ip] - istart*Lstart-1-Lmapped); //choose Shift for forward or reverse
 
                         //uint seedLength=min(splitR[1][ip] - Lmapped - istart*Lstart, P.seedSearchLmax);
-                        uint seedLength=splitR[1][ip] - Lmapped - istart*Lstart;
+                        uint seedLength=splitR[1][ip] - Lmapped - istart*Lstart; // what's left of the read to align.
                         maxMappableLength2strands(Shift, seedLength, iDir, 0, mapGen.nSA-1, L, splitR[2][ip]);//L=max mappable length, unique or multiple
                         if (iDir==0 && istart==0 && Lmapped==0 && Shift+L == splitR[1][ip] ) {//this piece maps full length and does not need to be mapped from the opposite direction
                             flagDirMap=false;
@@ -69,6 +79,7 @@ int ReadAlign::mapOneRead() {
                 };//if (flagDirMap || istart>0)
 
                 if (P.seedSearchLmax>0) {//search fixed length. Not very efficient, need to improve
+                    // off by default.
                     uint Shift = iDir==0 ? ( splitR[0][ip] + istart*Lstart ) : \
                                    ( splitR[0][ip] + splitR[1][ip] - istart*Lstart-1); //choose Shift for forward or reverse
                     uint seedLength = min(P.seedSearchLmax, iDir==0 ? (splitR[0][ip] + splitR[1][ip]-Shift):(Shift+1) );

--- a/source/ReadAlign_maxMappableLength2strands.cpp
+++ b/source/ReadAlign_maxMappableLength2strands.cpp
@@ -39,7 +39,7 @@ uint ReadAlign::maxMappableLength2strands(uint pieceStartIn, uint pieceLengthIn,
         //find SA boundaries
         uint Lind=Lmax;
         while (Lind>0) {//check the precense of the prefix for Lind
-            iSA1=mapGen.SAi[mapGen.genomeSAindexStart[Lind-1]+ind1];
+            iSA1=mapGen.SAi[mapGen.genomeSAindexStart[Lind-1]+ind1]; // starting point for suffix array search.
             if ((iSA1 & mapGen.SAiMarkAbsentMaskC) == 0) {//prefix exists
                 break;
             } else {//this prefix does not exist, reduce Lind
@@ -48,6 +48,7 @@ uint ReadAlign::maxMappableLength2strands(uint pieceStartIn, uint pieceLengthIn,
             };
         };
 
+        // define lower bound for suffix array range search.
         if (mapGen.genomeSAindexStart[Lind-1]+ind1+1 < mapGen.genomeSAindexStart[Lind]) {//we are not at the end of the SA
             iSA2=((mapGen.SAi[mapGen.genomeSAindexStart[Lind-1]+ind1+1] & mapGen.SAiMarkNmask) & mapGen.SAiMarkAbsentMask) - 1;
         } else {
@@ -63,6 +64,7 @@ uint ReadAlign::maxMappableLength2strands(uint pieceStartIn, uint pieceLengthIn,
         Nrep = maxMappableLength(mapGen, Read1, pieceStart, pieceLength, iSA1 & mapGen.SAiMarkNmask, iSA2, dirR, maxL, indStartEnd);
     #else
         if (Lind < P.pGe.gSAindexNbases && (iSA1 & mapGen.SAiMarkNmaskC)==0 ) {//no need for SA search
+            // very short seq, already found hits in suffix array w/o having to search the genome for extensions.
             indStartEnd[0]=iSA1;
             indStartEnd[1]=iSA2;
             Nrep=indStartEnd[1]-indStartEnd[0]+1;

--- a/source/ReadAlign_maxMappableLength2strands.cpp
+++ b/source/ReadAlign_maxMappableLength2strands.cpp
@@ -11,6 +11,10 @@ uint ReadAlign::maxMappableLength2strands(uint pieceStartIn, uint pieceLengthIn,
 
     bool dirR = iDir==0;
 
+    // defaults:  (from genomeParameters.txt)
+    // gSAsparseD = 1
+    // gSAindexNbases = 14
+
     for (uint iDist=0; iDist<min(pieceLengthIn,P.pGe.gSAsparseD); iDist++) {//cycle through different distances
         uint pieceStart;
         uint pieceLength=pieceLengthIn-iDist;
@@ -74,7 +78,7 @@ uint ReadAlign::maxMappableLength2strands(uint pieceStartIn, uint pieceLengthIn,
             bool comparRes;
             maxL=compareSeqToGenome(mapGen, Read1, pieceStart, pieceLength, Lind, iSA1, dirR, comparRes);
         } else {//SA search, pieceLength>maxL
-        if ( (iSA1 & mapGen.SAiMarkNmaskC)==0 ) {//no N in the prefix
+            if ( (iSA1 & mapGen.SAiMarkNmaskC)==0 ) {//no N in the prefix
                 maxL=Lind;
             } else {
                 maxL=0;

--- a/source/ReadAlign_stitchPieces.cpp
+++ b/source/ReadAlign_stitchPieces.cpp
@@ -40,6 +40,8 @@ void ReadAlign::stitchPieces(char **R, uint Lread) {
 
     nW=0; //number of windows
     for (uint iP=0; iP<nP; iP++) {//scan through all anchor pieces, create alignment windows
+        // np is number of pieces (stored seed alignments)
+
 
 //          if (PC[iP][PC_Nrep]<=P.winAnchorMultimapNmax || PC[iP][PC_Length]>=readLength[PC[iP][PC_iFrag]] ) {//proceed if piece is an anchor, i.e. maps few times or is long enough
        if (PC[iP][PC_Nrep]<=P.winAnchorMultimapNmax ) {//proceed if piece is an anchor, i.e. maps few times
@@ -48,7 +50,7 @@ void ReadAlign::stitchPieces(char **R, uint Lread) {
             uint aLength= PC[iP][PC_Length];
 
             for (uint iSA=PC[iP][PC_SAstart]; iSA<=PC[iP][PC_SAend]; iSA++) {//scan through all alignments of this piece
-
+                // going through ordered positions in the suffix array from PC_SAstart to PC_SAend
                 uint a1 = mapGen.SA[iSA];
                 uint aStr = a1 >> mapGen.GstrandBit;
                 a1 &= mapGen.GstrandMask; //remove strand bit
@@ -169,13 +171,13 @@ void ReadAlign::stitchPieces(char **R, uint Lread) {
                         assignAlignToWindow(a1D, aLengthD, aStr, aNrep, aFrag, aRstart, aAnchor, isj1);
                         assignAlignToWindow(a1A, aLengthA, aStr, aNrep, aFrag, aRstart+aLengthD, aAnchor, isj1);
 
-                    } else {//align does not cross the junction
+                  } else {//align does not cross the junction
                         continue; //do not check this align, continue to the next one
-                    };
+                  };
 
-                } else {//this is a normal genomic read
+              } else {//this is a normal genomic read
                     assignAlignToWindow(a1, aLength, aStr, aNrep, aFrag, aRstart, aAnchor, -1);
-                };
+              };
         };
 
 //         for (uint ii=0;ii<nW;ii++) {//check of some pieces created too many aligns in some windows, and remove those from WA (ie shift nWA indices
@@ -346,4 +348,3 @@ std::time(&timeStart);
     };
 
 };//end of function
-

--- a/source/SuffixArrayFuns.cpp
+++ b/source/SuffixArrayFuns.cpp
@@ -132,7 +132,7 @@ uint findMultRange(Genome &mapGen, uint i3, uint L3, uint i1, uint L1, uint i1a,
 
 uint maxMappableLength(Genome &mapGen, char** s, uint S, uint N, uint i1, uint i2, bool dirR, uint& L, uint* indStartEnd)
 {
-    /* find minimum mappable length of sequence s to the genome g with suffix array SA; length(s)=N; [i1 i2] is
+    /* find minimum mappable length of sequence s to the genome g with suffix array SA; length(s)=N; [i1 i2] is initial suffix array search bounds.
      * returns number of mappings (1=unique);range indStartEnd; min mapped length = L
      * binary search in SA space
      */
@@ -151,6 +151,16 @@ uint maxMappableLength(Genome &mapGen, char** s, uint S, uint N, uint i1, uint i
     L1a=L1;L1b=L1;i1a=i1;i1b=i1;
     L2a=L2;L2b=L2;i2a=i2;i2b=i2;   // track boundaries of best matching suffix array ranges
 
+
+    //  suffix array
+    // ---------------------------
+    //   i1, L1
+    //
+    //   i3, L3
+    //
+    //   i2, L2
+    // --------------------------
+
     i3=i1;L3=L1; //in case i1+1>=i2 an not iteration of the loope below is ever made
     while (i1+1<i2) {//main binary search loop
         i3=medianUint2(i1,i2);
@@ -161,6 +171,8 @@ uint maxMappableLength(Genome &mapGen, char** s, uint S, uint N, uint i1, uint i
         if (compRes) { //move 1 to 3
             if (L3>L1) {
                L1b=L1a; L1a=L1; i1b=i1a; i1a=i1;
+               // L1b, i1b - captures history of last time the max score shifted.
+               // L1a, i1a - tracks current shift.
             };
             i1=i3;L1=L3;
         }

--- a/source/SuffixArrayFuns.cpp
+++ b/source/SuffixArrayFuns.cpp
@@ -149,7 +149,7 @@ uint maxMappableLength(Genome &mapGen, char** s, uint S, uint N, uint i1, uint i
     L= min(L1,L2);
 
     L1a=L1;L1b=L1;i1a=i1;i1b=i1;
-    L2a=L2;L2b=L2;i2a=i2;i2b=i2;
+    L2a=L2;L2b=L2;i2a=i2;i2b=i2;   // track boundaries of best matching suffix array ranges
 
     i3=i1;L3=L1; //in case i1+1>=i2 an not iteration of the loope below is ever made
     while (i1+1<i2) {//main binary search loop

--- a/source/Transcript.h
+++ b/source/Transcript.h
@@ -58,7 +58,7 @@ public:
     void resetMapG(); // reset map to 0
     void resetMapG(uint); // reset map to 0 for Lread bases
     void add(Transcript*); // add
-    void alignScore(char **Read1, char *G, Parameters &P);
+    intScore alignScore(char **Read1, char *G, Parameters &P);
     int variationAdjust(const Genome &mapGen, char *R);
     string generateCigarP(); //generates CIGAR
     void peOverlapSEtoPE(uint* mSta, Transcript &t);

--- a/source/Transcript_alignScore.cpp
+++ b/source/Transcript_alignScore.cpp
@@ -1,7 +1,7 @@
 #include <cmath>
 #include "Transcript.h"
 
-void Transcript::alignScore(char **Read1, char *G, Parameters &P) {//re-calculates score and number of mismatches
+intScore Transcript::alignScore(char **Read1, char *G, Parameters &P) {//re-calculates score and number of mismatches
     maxScore=0;
     nMM=0;
     nMatch=0;
@@ -52,4 +52,5 @@ void Transcript::alignScore(char **Read1, char *G, Parameters &P) {//re-calculat
         maxScore += int(ceil( log2( (double) ( max(1LLU,exons[nExons-1][EX_G]+exons[nExons-1][EX_L] - exons[0][EX_G]) ) ) \
                  * P.scoreGenomicLengthLog2scale - 0.5));
     };
+    return maxScore;
 };

--- a/source/VERSION
+++ b/source/VERSION
@@ -1,1 +1,1 @@
-#define STAR_VERSION "2.7.1a"
+#define STAR_VERSION "2.7.1a_Chimeric_2"


### PR DESCRIPTION
The main thing that I did wrt chimera checking was to compare the alignment score of the chimeria to the best score of the non-chimeric alternative alignment.  If the non-chimeric alignment scored higher, then the chimera is excluded from reporting.  I included the score info in the chimeric.out.junction file so it's easy to track.  These additional fields include:

the maximum score possible (sum of read lengths)
the best non-chimeric alignment score
the chimeric alignment score for this chimeric alignment instance
the best chimeric alignment score across multimappers of this read
a flag indicating that the chimeric alignment was searched as a merged PE read or via the separate paired reads.

I also reorganized some of the logic around which chimeras to explore, pursuing the chimeric stitching for all candidates, but the initial candidate criterion (that the initial score be better than the non-chimeric alignment score) should prevent most chimeric candidates from moving on to the stitch phase.

I pulled in almost all of the updates from the chimeric_1 branch and made sure we're still doing good w/ the data that motivated those updates.