### PR TITLE
Fix documentation of chimNonchimScoreDropMin.

### DIFF
--- a/extras/doc-latex/STARmanual.tex
+++ b/extras/doc-latex/STARmanual.tex
@@ -521,7 +521,7 @@ Previous STAR chimeric detection algorithm only detected uniquely mapping chimer
 The new algorithm can detect and output multimapping chimeras. Presently, the only output into Chimeric.out.junction is supported.
 This algorithm is activated with $>0$ value in \optv{chimMultimapNmax}, which defines the maximum number of chimeric multi-alignments.
 The \optv{chimMultimapScoreRange} ($=1$ by default) parameter defines the score range for multi-mapping chimeras below the best chimeric score, similar to the \optv{outFilterMultimapScoreRange} parameter for normal alignments.
-The \optv{chimNonchimScoreDropMin} ($=20$ by default) defines the threshold triggering chimeric detection: the drop in the best non-chimeric alignment score with respect to the read length has to be smaller than this value.
+The \optv{chimNonchimScoreDropMin} ($=20$ by default) defines the threshold triggering chimeric detection: the drop in the best non-chimeric alignment score with respect to the read length has to be greater than this value.
 
 \section{STARsolo: mapping, demultiplexing and gene quantification for single cell RNA-seq}
 

--- a/extras/doc-latex/parametersDefault.tex
+++ b/extras/doc-latex/parametersDefault.tex
@@ -725,7 +725,7 @@
   \optLine{int{\textgreater}=0: the score range for multi-mapping chimeras below the best chimeric score. Only works with --chimMultimapNmax {\textgreater} 1} 
 \optName{chimNonchimScoreDropMin}
   \optValue{20}
-  \optLine{int{\textgreater}=0: to trigger chimeric detection, the drop in the best non-chimeric alignment score with respect to the read length has to be smaller than this value} 
+  \optLine{int{\textgreater}=0: to trigger chimeric detection, the drop in the best non-chimeric alignment score with respect to the read length has to be greater than this value} 
 \optName{chimOutJunctionFormat}
   \optValue{0}
   \optLine{int: formatting type for the Chimeric.out.junction file} 

--- a/source/parametersDefault
+++ b/source/parametersDefault
@@ -626,7 +626,7 @@ chimMultimapScoreRange          1
     int>=0: the score range for multi-mapping chimeras below the best chimeric score. Only works with --chimMultimapNmax > 1
 
 chimNonchimScoreDropMin         20
-    int>=0: to trigger chimeric detection, the drop in the best non-chimeric alignment score with respect to the read length has to be smaller than this value
+    int>=0: to trigger chimeric detection, the drop in the best non-chimeric alignment score with respect to the read length has to be greater than this value
 
 chimOutJunctionFormat           0
     int: formatting type for the Chimeric.out.junction file


### PR DESCRIPTION
I may well be misunderstanding, but I think the `chimNonchimScoreDropMin` parameter specifies the minimum difference between the read length and the max non-chimeric alignment score to trigger chimeric detection. This is consistent with the parameter name and also my reading of https://github.com/alexdobin/STAR/blob/2.7.2a/source/ReadAlign_chimericDetection.cpp#L48. I think this means then that `the drop in the best non-chimeric alignment score with respect to the read length` needs to be _greater_ than the specified value.