### PR TITLE
Fix memory leak in handling chimeric multimappers.

### DIFF
--- a/source/ChimericDetection_chimericDetectionMult.cpp
+++ b/source/ChimericDetection_chimericDetectionMult.cpp
@@ -86,7 +86,12 @@ bool ChimericDetection::chimericDetectionMult(uint nW, uint *readLength, int max
 
                             if (chimAligns.back().chimScore > chimScoreBest)
                                 chimScoreBest=chimAligns.back().chimScore;
-                        }; // endif stitched chimera survived.
+                        } // endif stitched chimera survived.
+                        else {
+                            // al1, al2 allocated during stitching
+                            delete chAl.al1;
+                            delete chAl.al2;
+                        };
 
                     }; // endif meets chim score criteria
                 };//cycle over window2 aligns


### PR DESCRIPTION
In 2.7.2a, there's a memory leak in handling chimeric multimappers, where low-scoring candidate chimeric alignments that are discarded do not have their memory deallocated. This issue predates 2.7.2a, but with recent updates, `chimericStitching`, where the memory is allocated, is called more frequently than previously, making the problem more visible, causing out of memory crashes even with 156GB of memory allotted for aligning human data.

On a test data set with single-threaded 2-pass mapping, I have verified that outputs are the same before and after patching. Specifically:
* Log.final.out mapping statistics are identical
* Chimeric.out.junction identical
* SJ.out.tab identical
* coordinate sorted BAM contents match using [BamUtil](https://genome.sph.umich.edu/wiki/BamUtil:_diff) to diff (`bam diff --all`)
* transcriptome BAM contents match using [BamUtil](https://genome.sph.umich.edu/wiki/BamUtil:_diff) to diff (`bam diff --all`)

Memory usage confirmed to drop back within a typical range.