### PR TITLE
avoid undefined behaviour 

### DIFF
--- a/source/Genome_genomeGenerate.cpp
+++ b/source/Genome_genomeGenerate.cpp
@@ -294,8 +294,7 @@ void Genome::genomeGenerate() {
         //uint saChunkN=((nSA/saChunkSize+1)/P.runThreadN+1)*P.runThreadN;//ensure saChunkN is divisible by P.runThreadN
         //saChunkSize=nSA/saChunkN+100000;//final chunk size
         if (P.runThreadN>1) saChunkSize=min(saChunkSize,nSA/(P.runThreadN-1));
-
-        uint saChunkN=nSA/saChunkSize;//estimate
+        uint saChunkN = nSA / saChunkSize + 1;//estimate
         uint* indPrefStart = new uint [saChunkN*2]; //start and stop, *2 just in case
         uint* indPrefChunkCount = new uint [saChunkN*2];
         indPrefStart[0]=0;

--- a/source/STAR.cpp
+++ b/source/STAR.cpp
@@ -40,7 +40,8 @@ void usage(int usageType) {
     if (usageType==0) {//brief
         cout << "\nTo list all parameters, run STAR --help\n";
     } else {//full
-        cout <<'\n'<< parametersDefault;
+        cout.write(reinterpret_cast<char *> (parametersDefault),
+                   parametersDefault_len);
     };
     exit(0);
 }


### PR DESCRIPTION
1) If `nSA < saChunkSize`, `saChunkN` equals 0.
It leads to undefined behaviour here
```
uint* indPrefStart = new uint [0];
uint* indPrefChunkCount = new uint [0];
```
2) minor fix: parametersDefault is not null-terminated, 
and its length should be provided explicitly for `std::cout`.