### PR TITLE
mapping performance improvement

### DIFF
--- a/source/ErrorWarning.cpp
+++ b/source/ErrorWarning.cpp
@@ -5,7 +5,7 @@
 #include "TimeFunctions.h"
 #include "GlobalVariables.h"
 
-void exitWithError(string messageOut, ostream &streamOut1, ostream &streamOut2, int errorInt, Parameters &P) {
+void exitWithError(string messageOut, ostream &streamOut1, ostream &streamOut2, int errorInt, const Parameters &P) {
     time_t timeCurrent;
     time( &timeCurrent);
     if (P.runThreadN>1) pthread_mutex_lock(&g_threadChunks.mutexError);

--- a/source/ErrorWarning.h
+++ b/source/ErrorWarning.h
@@ -4,6 +4,6 @@
 #include "IncludeDefine.h"
 #include "Parameters.h"
 
-void exitWithError(string messageOut, ostream &streamOut1, ostream &streamOut2, int errorInt, Parameters &P);
+void exitWithError(string messageOut, ostream &streamOut1, ostream &streamOut2, int errorInt, const Parameters &P);
 void warningMessage(string messageOut, ostream &streamOut1, ostream &streamOut2, Parameters &P);
 #endif

--- a/source/ReadAlign_assignAlignToWindow.cpp
+++ b/source/ReadAlign_assignAlignToWindow.cpp
@@ -13,10 +13,15 @@ void ReadAlign::assignAlignToWindow(uint a1, uint aLength, uint aStr, uint aNrep
     {//do not check for overlap if this is an sj-align
         uint iA;
         for (iA=0; iA<nWA[iW]; iA++) {
-            if (aFrag==WA[iW][iA][WA_iFrag] && WA[iW][iA][WA_sjA]==sjA \
-                && a1+WA[iW][iA][WA_rStart]==WA[iW][iA][WA_gStart]+aRstart \
-                && ( (aRstart>=WA[iW][iA][WA_rStart] && aRstart<WA[iW][iA][WA_rStart]+WA[iW][iA][WA_Length]) \
-                  || (aRstart+aLength>=WA[iW][iA][WA_rStart] && aRstart+aLength<WA[iW][iA][WA_rStart]+WA[iW][iA][WA_Length]) ) ) {//this piece overlaps with iA
+          auto& align = WA[iW][iA];
+          if (a1+align[WA_rStart]==align[WA_gStart]+aRstart
+              && aFrag==align[WA_iFrag]
+              && align[WA_sjA]==sjA
+              && ((aRstart >= align[WA_rStart] &&
+                    aRstart < align[WA_rStart]+align[WA_Length])
+                   || (aRstart+aLength>=align[WA_rStart]
+                       && aRstart+aLength<align[WA_rStart]+align[WA_Length]))) {
+            //this piece overlaps with iA
                 break;
             };
         };

--- a/source/ReadAlign_outputTranscriptSAM.cpp
+++ b/source/ReadAlign_outputTranscriptSAM.cpp
@@ -232,7 +232,7 @@ uint ReadAlign::outputTranscriptSAM(Transcript const &trOut, uint nTrOut, uint i
         } else if (mateChr<mapGen.nChrReal){//mateChr is given in the function parameters
             *outStream <<"\t"<< mapGen.chrName[mateChr] <<"\t"<< mateStart+1-mapGen.chrStart[mateChr] <<"\t"<< 0;
         } else {
-            *outStream <<"\t"<< "*" <<"\t"<< 0 <<"\t"<< 0;
+            *outStream << "\t*\t0\t0";
         };
 
 

--- a/source/Transcript.h
+++ b/source/Transcript.h
@@ -64,7 +64,7 @@ public:
     void resetMapG(uint); // reset map to 0 for Lread bases
     void add(Transcript*); // add
     intScore alignScore(char **Read1, char *G, Parameters &P);
-    int variationAdjust(const Genome &mapGen, char *R);
+    int variationAdjust(const Genome &mapGen, const char *R);
     string generateCigarP(); //generates CIGAR
     void peOverlapSEtoPE(uint* mSta, Transcript &t);
     void extractSpliceJunctions(vector<array<uint64,2>> &sjOut, bool &annotYes);

--- a/source/Transcript_variationAdjust.cpp
+++ b/source/Transcript_variationAdjust.cpp
@@ -1,7 +1,7 @@
 #include "Transcript.h"
 #include "serviceFuns.cpp"
 
-int Transcript::variationAdjust(const Genome &mapGen, char *R)
+int Transcript::variationAdjust(const Genome &mapGen, const char *R)
 {
     Variation &Var=*mapGen.Var;
 

--- a/source/extendAlign.cpp
+++ b/source/extendAlign.cpp
@@ -3,7 +3,7 @@
 #include "Transcript.h"
 #include "extendAlign.h"
 
-bool extendAlign( char* R, char* G, uint rStart, uint gStart, int dR, int dG, uint L, uint Lprev, uint nMMprev, uint nMMmax, double pMMmax, bool extendToEnd, Transcript* trA ) {
+bool extendAlign(const char* R, const char* G, uint rStart, uint gStart, int dR, int dG, uint L, uint Lprev, uint nMMprev, uint nMMmax, double pMMmax, bool extendToEnd, Transcript* trA ) {
 
 // find the maximum score
 

--- a/source/extendAlign.h
+++ b/source/extendAlign.h
@@ -2,5 +2,5 @@
 #include "Parameters.h"
 #include "Transcript.h"
 
-bool extendAlign( char* R, char* G, uint rStart, uint gStart, int dR, int dG, uint L, uint Lprev, uint nMMprev, uint nMMmax, double pMMmax, bool extendToEnd, Transcript* trA );
+bool extendAlign(const char* R, const char* G, uint rStart, uint gStart, int dR, int dG, uint L, uint Lprev, uint nMMprev, uint nMMmax, double pMMmax, bool extendToEnd, Transcript* trA );
 

--- a/source/stitchAlignToTranscript.cpp
+++ b/source/stitchAlignToTranscript.cpp
@@ -6,7 +6,10 @@
 // #include "stitchGapIndel.cpp"
 
 
-intScore stitchAlignToTranscript(uint rAend, uint gAend, uint rBstart, uint gBstart, uint L, uint iFragB, uint sjAB, Parameters& P, char* R, Genome &mapGen, Transcript *trA, const uint outFilterMismatchNmaxTotal) {
+intScore stitchAlignToTranscript(uint rAend, uint gAend, uint rBstart,
+                                 uint gBstart, uint L, uint iFragB, uint sjAB,
+                                 const Parameters& P, char* R, Genome &mapGen,
+                                 Transcript *trA, const uint outFilterMismatchNmaxTotal) {
     //stitch together A and B, extend in the gap, returns max score
 
     if (trA->nExons>=MAX_N_EXONS)

--- a/source/stitchAlignToTranscript.cpp
+++ b/source/stitchAlignToTranscript.cpp
@@ -8,7 +8,7 @@
 
 intScore stitchAlignToTranscript(uint rAend, uint gAend, uint rBstart,
                                  uint gBstart, uint L, uint iFragB, uint sjAB,
-                                 const Parameters& P, char* R, Genome &mapGen,
+                                 const Parameters& P, const char* R, const Genome &mapGen,
                                  Transcript *trA, const uint outFilterMismatchNmaxTotal) {
     //stitch together A and B, extend in the gap, returns max score
 

--- a/source/stitchAlignToTranscript.h
+++ b/source/stitchAlignToTranscript.h
@@ -1,7 +1,10 @@
+#include "Genome.h"
 #include "IncludeDefine.h"
 #include "Parameters.h"
 #include "Transcript.h"
-#include "Genome.h"
 
-intScore stitchAlignToTranscript(uint rAend, uint gAend, uint rBstart, uint gBstart, uint L, uint iFragB, uint sjAB, Parameters& P, char* R, Genome &mapGen,  Transcript *trA, uint outFilterMismatchNmaxTotal);
-
+intScore stitchAlignToTranscript(uint rAend, uint gAend, uint rBstart,
+                                 uint gBstart, uint L, uint iFragB, uint sjAB,
+                                 const Parameters &P, const char *R,
+                                 const Genome &mapGen, Transcript *trA,
+                                 uint outFilterMismatchNmaxTotal);

--- a/source/stitchWindowAligns.cpp
+++ b/source/stitchWindowAligns.cpp
@@ -386,7 +386,6 @@ void stitchWindowAligns(uint iA, uint nA, int Score, bool WAincl[], uint tR2, ui
       return;
     };
 
-    ///////////////////////////////////////////////////////////////////////////////////
     int dScore=0;
     Transcript trAi=trA; //trA copy with this align included, to be used in the 1st recursive call of StitchAlign
     if (trA.nExons>0) {//stitch, a transcript has already been originated
@@ -400,16 +399,11 @@ void stitchWindowAligns(uint iA, uint nA, int Score, bool WAincl[], uint tR2, ui
             trAi.exons[0][EX_L]=WA[iA][WA_Length];
             trAi.exons[0][EX_iFrag]=WA[iA][WA_iFrag];
             trAi.exons[0][EX_sjA]=WA[iA][WA_sjA];
-
             trAi.nExons=1; //recorded first exon
-
-            for (uint ii=0;ii<WA[iA][WA_Length];ii++) dScore+=scoreMatch; //sum all the scores
-
             trAi.nMatch=WA[iA][WA_Length]; //# of matches
 
+            for (uint ii=0;ii<WA[iA][WA_Length];ii++) dScore+=scoreMatch; //sum all the scores
             for (uint ii=0; ii<nA; ii++) WAincl[ii]=false;
-
-
     };
 
     if (dScore>-1000000) {//include this align
@@ -419,8 +413,6 @@ void stitchWindowAligns(uint iA, uint nA, int Score, bool WAincl[], uint tR2, ui
         if ( WA[iA][WA_Anchor]>0 ) trAi.nAnchor++; //anchor piece piece
 
         stitchWindowAligns(iA+1, nA, Score+dScore, WAincl, WA[iA][WA_rStart]+WA[iA][WA_Length]-1, WA[iA][WA_gStart]+WA[iA][WA_Length]-1, trAi, Lread, WA, R, mapGen, P, wTr, nWinTr, RA);
-    } else {
-
     };
 
     //also run a transcript w/o including this align

--- a/source/stitchWindowAligns.cpp
+++ b/source/stitchWindowAligns.cpp
@@ -400,7 +400,7 @@ void finalizeTranscript(ReadAlign *RA, Transcript **wTr, uint *nWinTr,
 }
 
 void stitchWindowAligns(uint iA, uint nA, int Score, bool WAincl[], uint tR2, uint tG2, const Transcript& trA,
-                        uint Lread, uiWA* WA, char* R, const Genome &mapGen,
+                        uint Lread, const uiWA* WA, const char* R, const Genome &mapGen,
                         const Parameters& P, Transcript** wTr, uint* nWinTr, ReadAlign *RA) {
     //recursively stitch aligns for one gene
     //*nWinTr - number of transcripts for the current window

--- a/source/stitchWindowAligns.cpp
+++ b/source/stitchWindowAligns.cpp
@@ -33,17 +33,19 @@ bool isAlignToSkip(uint rAend, uint gAend, uint rBstart, uint gBstart, uint L,
 }
 
 void finalizeTranscript(ReadAlign *RA, Transcript **wTr, uint *nWinTr,
-                        const Parameters &P, const Genome &mapGen, const char *R, uint Lread,
-                        Transcript trA, uint tG2, uint tR2, int Score) {
+                        const Parameters &P, const Genome &mapGen,
+                        const char *R, uint Lread, Transcript trA, uint tG2,
+                        uint tR2, int Score) {
 
   // extend first
   Transcript trAstep1;
-  
+
   int vOrder[2]; // decide in which order to extend: extend the 5' of the read
                  // first
 
 #if EXTEND_ORDER == 1
-  if (trA.roStr == 0) { // decide in which order to extend: extend the 5' of the read first
+  if (trA.roStr == 0) {
+    // decide in which order to extend: extend the 5' of the read first
     vOrder[0] = 0;
     vOrder[1] = 1;
   } else {
@@ -62,9 +64,8 @@ void finalizeTranscript(ReadAlign *RA, Transcript **wTr, uint *nWinTr,
     switch (vOrder[iOrd]) {
 
     case 0: // extend at start
-
-      if (trA.rStart >
-          0) { // if transcript does not start at base, extend to the read start
+      if (trA.rStart > 0) {
+        // if transcript does not start at base, extend to the read start
         trAstep1.reset();
         uint imate = trA.exons[0][EX_iFrag];
         if (extendAlign(R, mapGen.G, trA.rStart - 1, trA.gStart - 1, -1, -1,
@@ -102,9 +103,8 @@ void finalizeTranscript(ReadAlign *RA, Transcript **wTr, uint *nWinTr,
 
           tR2 += trAstep1.extendL;
           tG2 += trAstep1.extendL;
-
-          trA.exons[trA.nExons - 1][EX_L] +=
-            trAstep1.extendL; // extend the length of the last exon
+          // extend the length of the last exon
+          trA.exons[trA.nExons - 1][EX_L] += trAstep1.extendL;
         };
         // TODO penalize unmapped bases at the end
       };
@@ -114,7 +114,7 @@ void finalizeTranscript(ReadAlign *RA, Transcript **wTr, uint *nWinTr,
   if (!P.alignSoftClipAtReferenceEnds.yes &&
       ((trA.exons[trA.nExons - 1][EX_G] + Lread -
         trA.exons[trA.nExons - 1][EX_R]) >
-       (mapGen.chrStart[trA.Chr] + mapGen.chrLength[trA.Chr]) ||
+           (mapGen.chrStart[trA.Chr] + mapGen.chrLength[trA.Chr]) ||
        trA.exons[0][EX_G] < (mapGen.chrStart[trA.Chr] + trA.exons[0][EX_R]))) {
     return; // no soft clipping past the ends of the chromosome
   };
@@ -127,9 +127,9 @@ void finalizeTranscript(ReadAlign *RA, Transcript **wTr, uint *nWinTr,
 
   // check exons lengths including repeats, do not report a transcript with
   // short exons
-  for (uint isj = 0; isj < trA.nExons - 1;
-       isj++) { // check exons for min length, if they are not annotated and
-                // precede a junction
+  for (uint isj = 0; isj < trA.nExons - 1; isj++) {
+    // check exons for min length, if they are not annotated
+    //   and  precede a junction
     if (trA.canonSJ[isj] >= 0) {   // junction
       if (trA.sjAnnot[isj] == 1) { // sjdb
         if ((trA.exons[isj][EX_L] < P.alignSJDBoverhangMin &&
@@ -142,7 +142,7 @@ void finalizeTranscript(ReadAlign *RA, Transcript **wTr, uint *nWinTr,
       } else { // non-sjdb
         if (trA.exons[isj][EX_L] < P.alignSJoverhangMin + trA.shiftSJ[isj][0] ||
             trA.exons[isj + 1][EX_L] <
-            P.alignSJoverhangMin + trA.shiftSJ[isj][1])
+                P.alignSJoverhangMin + trA.shiftSJ[isj][1])
           return;
       };
     };
@@ -176,8 +176,8 @@ void finalizeTranscript(ReadAlign *RA, Transcript **wTr, uint *nWinTr,
       P.outFilterIntronStrands == "RemoveInconsistentStrands")
     return;
 
-  if (sjN > 0 && trA.sjMotifStrand == 0 &&
-      P.outSAMstrandField.type == 1) { // strand not defined for a junction
+  if (sjN > 0 && trA.sjMotifStrand == 0 && P.outSAMstrandField.type == 1) {
+    // strand not defined for a junction
     return;
   };
 
@@ -196,10 +196,10 @@ void finalizeTranscript(ReadAlign *RA, Transcript **wTr, uint *nWinTr,
   } else {
     ostringstream errOut;
     errOut << "EXITING because of FATAL INPUT error: unrecognized value of "
-      "--outFilterIntronMotifs="
+              "--outFilterIntronMotifs="
            << P.outFilterIntronMotifs << "\n";
     errOut << "SOLUTION: re-run STAR with --outFilterIntronMotifs = None -OR- "
-      "RemoveNoncanonical -OR- RemoveNoncanonicalUnannotated\n";
+              "RemoveNoncanonical -OR- RemoveNoncanonicalUnannotated\n";
     exitWithError(errOut.str(), std::cerr, P.inOut->logMain,
                   EXIT_CODE_INPUT_FILES, P);
   };
@@ -224,7 +224,8 @@ void finalizeTranscript(ReadAlign *RA, Transcript **wTr, uint *nWinTr,
     };
   };
 
-  if (P.outFilterBySJoutStage == 2) { // junctions have to be present in the filtered set P.sjnovel
+  if (P.outFilterBySJoutStage == 2) {
+    // junctions have to be present in the filtered set P.sjnovel
     for (uint iex = 0; iex < trA.nExons - 1; iex++) {
       if (trA.canonSJ[iex] >= 0 && trA.sjAnnot[iex] == 0) {
         uint jS = trA.exons[iex][EX_G] + trA.exons[iex][EX_L];
@@ -235,9 +236,8 @@ void finalizeTranscript(ReadAlign *RA, Transcript **wTr, uint *nWinTr,
     };
   };
 
-  if (trA.exons[0][EX_iFrag] !=
-      trA.exons[trA.nExons - 1]
-      [EX_iFrag]) { // check for correct overlap between mates
+  if (trA.exons[0][EX_iFrag] != trA.exons[trA.nExons - 1][EX_iFrag]) {
+    // check for correct overlap between mates
     if (trA.exons[trA.nExons - 1][EX_G] + trA.exons[trA.nExons - 1][EX_L] <=
         trA.exons[0][EX_G])
       return; // to avoid negative insert size
@@ -251,15 +251,15 @@ void finalizeTranscript(ReadAlign *RA, Transcript **wTr, uint *nWinTr,
     };
 
     if (trA.exons[iexM2 - 1][EX_G] + trA.exons[iexM2 - 1][EX_L] >
-        trA.exons[iexM2]
-        [EX_G]) { // mates overlap - check consistency of junctions
+        trA.exons[iexM2][EX_G]) {
+      // mates overlap - check consistency of junctions
 
       if (trA.exons[0][EX_G] > trA.exons[iexM2][EX_G] + trA.exons[0][EX_R] +
-          P.alignEndsProtrude.nBasesMax)
+                                   P.alignEndsProtrude.nBasesMax)
         return; // LeftMateStart > RightMateStart + allowance
       if (trA.exons[iexM2 - 1][EX_G] + trA.exons[iexM2 - 1][EX_L] >
           trA.exons[trA.nExons - 1][EX_G] + Lread -
-          trA.exons[trA.nExons - 1][EX_R] + P.alignEndsProtrude.nBasesMax)
+              trA.exons[trA.nExons - 1][EX_R] + P.alignEndsProtrude.nBasesMax)
         return; // LeftMateEnd   > RightMateEnd +allowance
 
       // check for junctions consistency
@@ -270,8 +270,8 @@ void finalizeTranscript(ReadAlign *RA, Transcript **wTr, uint *nWinTr,
             trA.exons[iex2 - 1][EX_G] + trA.exons[iex2 - 1][EX_L])
           break;
       };
-      while (iex1 < iexM2 &&
-             iex2 < trA.nExons) {        // cycle through all overlapping exons
+      while (iex1 < iexM2 && iex2 < trA.nExons) {
+        // cycle through all overlapping exons
         if (trA.canonSJ[iex1 - 1] < 0) { // skip non-junctions
           iex1++;
           continue;
@@ -304,7 +304,8 @@ void finalizeTranscript(ReadAlign *RA, Transcript **wTr, uint *nWinTr,
 
   // calculate some final values for the transcript
 
-  trA.roStart = (trA.roStr == 0) ? trA.rStart : Lread - trA.rStart - trA.rLength;
+  trA.roStart =
+      (trA.roStr == 0) ? trA.rStart : Lread - trA.rStart - trA.rLength;
   trA.maxScore = Score;
 
   if (trA.exons[0][EX_iFrag] ==
@@ -344,31 +345,33 @@ void finalizeTranscript(ReadAlign *RA, Transcript **wTr, uint *nWinTr,
 
     uint iTr = 0; // transcript insertion/replacement place
 
+    // caclulate total mapped length
     trA.mappedLength = 0;
-    for (uint iex = 0; iex < trA.nExons; iex++) { // caclulate total mapped length
+    for (uint iex = 0; iex < trA.nExons; iex++) {
       trA.mappedLength += trA.exons[iex][EX_L];
     };
 
-    while (iTr < *nWinTr) { // scan through all recorded transcripts for this
-                            // window - check for duplicates
+    // scan through all recorded transcripts for this window -
+    // check for duplicates
+    while (iTr < *nWinTr) {
 
       // another way to calculate uOld, uNew: w/o gMap
       uint nOverlap = blocksOverlap(trA, *wTr[iTr]);
       uint uNew = trA.mappedLength - nOverlap;
       uint uOld = wTr[iTr]->mappedLength - nOverlap;
 
-      if (uNew == 0 && Score < wTr[iTr]->maxScore) { // new transript is a subset of the old ones
+      if (uNew == 0 && Score < wTr[iTr]->maxScore) {
+        // new transript is a subset of the old ones
         break;
-      } else if (uOld == 0) { // old transcript is a subset of the new one,
-                              // remove old transcript
+      } else if (uOld == 0) {
+        // old transcript is a subset of the new one, remove old transcript
         Transcript *pTr = wTr[iTr];
         for (uint ii = iTr + 1; ii < *nWinTr; ii++)
           wTr[ii - 1] = wTr[ii]; // shift transcripts
         (*nWinTr)--;
         wTr[*nWinTr] = pTr;
-      } else if (uOld > 0 &&
-                 (uNew > 0 ||
-                  Score >= wTr[iTr]->maxScore)) { // check next transcript
+      } else if (uOld > 0 && (uNew > 0 || Score >= wTr[iTr]->maxScore)) {
+        // check next transcript
         iTr++;
       };
     };
@@ -381,11 +384,12 @@ void finalizeTranscript(ReadAlign *RA, Transcript **wTr, uint *nWinTr,
       };
 
       Transcript *pTr = wTr[*nWinTr];
-      for (int ii = *nWinTr; ii > int(iTr); ii--) { // shift all the transcript pointers down from iTr
+      for (int ii = *nWinTr; ii > int(iTr); ii--) {
+        // shift all the transcript pointers down from iTr
         wTr[ii] = wTr[ii - 1];
       };
-      wTr[iTr] = pTr; // the new transcript pointer is now at *nWinTr+1, move it
-                      // into the iTr
+      // the new transcript pointer is now at *nWinTr+1, move it into the iTr
+      wTr[iTr] = pTr;
       *(wTr[iTr]) = trA;
       if (*nWinTr < P.alignTranscriptsPerWindowNmax) {
         (*nWinTr)++; // increment number of transcripts per window;
@@ -454,5 +458,3 @@ void stitchWindowAligns(uint iA, uint nA, int Score, bool WAincl[], uint tR2, ui
     };
     return;
 };
-
-

--- a/source/stitchWindowAligns.cpp
+++ b/source/stitchWindowAligns.cpp
@@ -7,8 +7,8 @@
 
 
 void finalizeTranscript(ReadAlign *RA, Transcript **wTr, uint *nWinTr,
-                        Parameters &P, Genome &mapGen, char *R, uint Lread,
-                        Transcript& trA, uint tG2, uint tR2, int Score) {
+                        const Parameters &P, const Genome &mapGen, const char *R, uint Lread,
+                        Transcript trA, uint tG2, uint tR2, int Score) {
 
   // extend first
   Transcript trAstep1;
@@ -373,9 +373,9 @@ void finalizeTranscript(ReadAlign *RA, Transcript **wTr, uint *nWinTr,
   return;
 }
 
-void stitchWindowAligns(uint iA, uint nA, int Score, bool WAincl[], uint tR2, uint tG2, Transcript trA, \
-                        uint Lread, uiWA* WA, char* R, Genome &mapGen, \
-                        Parameters& P, Transcript** wTr, uint* nWinTr, ReadAlign *RA) {
+void stitchWindowAligns(uint iA, uint nA, int Score, bool WAincl[], uint tR2, uint tG2, const Transcript& trA,
+                        uint Lread, uiWA* WA, char* R, const Genome &mapGen,
+                        const Parameters& P, Transcript** wTr, uint* nWinTr, ReadAlign *RA) {
     //recursively stitch aligns for one gene
     //*nWinTr - number of transcripts for the current window
 

--- a/source/stitchWindowAligns.cpp
+++ b/source/stitchWindowAligns.cpp
@@ -5,6 +5,374 @@
 #include <cmath>
 #include <ctime>
 
+
+void finalizeTranscript(ReadAlign *RA, Transcript **wTr, uint *nWinTr,
+                        Parameters &P, Genome &mapGen, char *R, uint Lread,
+                        Transcript& trA, uint tG2, uint tR2, int Score) {
+
+  // extend first
+  Transcript trAstep1;
+  
+  int vOrder[2]; // decide in which order to extend: extend the 5' of the read
+                 // first
+
+#if EXTEND_ORDER == 1
+  if (trA.roStr == 0) { // decide in which order to extend: extend the 5' of the read first
+    vOrder[0] = 0;
+    vOrder[1] = 1;
+  } else {
+    vOrder[0] = 1;
+    vOrder[1] = 0;
+  };
+#elif EXTEND_ORDER == 2
+  vOrder[0] = 0;
+  vOrder[1] = 1;
+#else
+#error "EXTEND_ORDER value unrecognized"
+#endif
+
+  for (int iOrd = 0; iOrd < 2; iOrd++) {
+
+    switch (vOrder[iOrd]) {
+
+    case 0: // extend at start
+
+      if (trA.rStart >
+          0) { // if transcript does not start at base, extend to the read start
+        trAstep1.reset();
+        uint imate = trA.exons[0][EX_iFrag];
+        if (extendAlign(R, mapGen.G, trA.rStart - 1, trA.gStart - 1, -1, -1,
+                        trA.rStart, tR2 - trA.rStart + 1, trA.nMM,
+                        RA->outFilterMismatchNmaxTotal,
+                        P.outFilterMismatchNoverLmax,
+                        P.alignEndsType.ext[imate][(int)(trA.Str != imate)],
+                        &trAstep1)) { // if could extend
+
+          trA.add(&trAstep1);
+          Score += trAstep1.maxScore;
+
+          trA.exons[0][EX_R] = trA.rStart = trA.rStart - trAstep1.extendL;
+          trA.exons[0][EX_G] = trA.gStart = trA.gStart - trAstep1.extendL;
+          trA.exons[0][EX_L] += trAstep1.extendL;
+        };
+        // TODO penalize the unmapped bases at the start
+      };
+      break;
+
+    case 1: // extend at end
+
+      if (tR2 < Lread) { // extend alignment to the read end
+        trAstep1.reset();
+        uint imate = trA.exons[trA.nExons - 1][EX_iFrag];
+        if (extendAlign(R, mapGen.G, tR2 + 1, tG2 + 1, +1, +1, Lread - tR2 - 1,
+                        tR2 - trA.rStart + 1, trA.nMM,
+                        RA->outFilterMismatchNmaxTotal,
+                        P.outFilterMismatchNoverLmax,
+                        P.alignEndsType.ext[imate][(int)(imate == trA.Str)],
+                        &trAstep1)) { // if could extend
+
+          trA.add(&trAstep1);
+          Score += trAstep1.maxScore;
+
+          tR2 += trAstep1.extendL;
+          tG2 += trAstep1.extendL;
+
+          trA.exons[trA.nExons - 1][EX_L] +=
+            trAstep1.extendL; // extend the length of the last exon
+        };
+        // TODO penalize unmapped bases at the end
+      };
+    };
+  };
+
+  if (!P.alignSoftClipAtReferenceEnds.yes &&
+      ((trA.exons[trA.nExons - 1][EX_G] + Lread -
+        trA.exons[trA.nExons - 1][EX_R]) >
+       (mapGen.chrStart[trA.Chr] + mapGen.chrLength[trA.Chr]) ||
+       trA.exons[0][EX_G] < (mapGen.chrStart[trA.Chr] + trA.exons[0][EX_R]))) {
+    return; // no soft clipping past the ends of the chromosome
+  };
+
+  trA.rLength = 0;
+  for (uint isj = 0; isj < trA.nExons; isj++) {
+    trA.rLength += trA.exons[isj][EX_L];
+  };
+  trA.gLength = tG2 + 1 - trA.gStart;
+
+  // check exons lengths including repeats, do not report a transcript with
+  // short exons
+  for (uint isj = 0; isj < trA.nExons - 1;
+       isj++) { // check exons for min length, if they are not annotated and
+                // precede a junction
+    if (trA.canonSJ[isj] >= 0) {   // junction
+      if (trA.sjAnnot[isj] == 1) { // sjdb
+        if ((trA.exons[isj][EX_L] < P.alignSJDBoverhangMin &&
+             (isj == 0 || trA.canonSJ[isj - 1] == -3 ||
+              (trA.sjAnnot[isj - 1] == 0 && trA.canonSJ[isj - 1] >= 0))) ||
+            (trA.exons[isj + 1][EX_L] < P.alignSJDBoverhangMin &&
+             (isj == trA.nExons - 2 || trA.canonSJ[isj + 1] == -3 ||
+              (trA.sjAnnot[isj + 1] == 0 && trA.canonSJ[isj + 1] >= 0))))
+          return;
+      } else { // non-sjdb
+        if (trA.exons[isj][EX_L] < P.alignSJoverhangMin + trA.shiftSJ[isj][0] ||
+            trA.exons[isj + 1][EX_L] <
+            P.alignSJoverhangMin + trA.shiftSJ[isj][1])
+          return;
+      };
+    };
+  };
+  if (trA.nExons > 1 && trA.sjAnnot[trA.nExons - 2] == 1 &&
+      trA.exons[trA.nExons - 1][EX_L] < P.alignSJDBoverhangMin)
+    return; // this exon was not checkedin the cycle above
+
+  // filter strand consistency
+  uint sjN = 0;
+  trA.intronMotifs[0] = 0;
+  trA.intronMotifs[1] = 0;
+  trA.intronMotifs[2] = 0;
+  trA.sjYes = false;
+  for (uint iex = 0; iex < trA.nExons - 1; iex++) {
+    if (trA.canonSJ[iex] >= 0) { // junctions - others are indels
+      sjN++;
+      trA.intronMotifs[trA.sjStr[iex]]++;
+      trA.sjYes = true;
+    };
+  };
+
+  if (trA.intronMotifs[1] > 0 && trA.intronMotifs[2] == 0)
+    trA.sjMotifStrand = 1;
+  else if (trA.intronMotifs[1] == 0 && trA.intronMotifs[2] > 0)
+    trA.sjMotifStrand = 2;
+  else
+    trA.sjMotifStrand = 0;
+
+  if (trA.intronMotifs[1] > 0 && trA.intronMotifs[2] > 0 &&
+      P.outFilterIntronStrands == "RemoveInconsistentStrands")
+    return;
+
+  if (sjN > 0 && trA.sjMotifStrand == 0 &&
+      P.outSAMstrandField.type == 1) { // strand not defined for a junction
+    return;
+  };
+
+  if (P.outFilterIntronMotifs == "None") { // no filtering
+
+  } else if (P.outFilterIntronMotifs == "RemoveNoncanonical") {
+    for (uint iex = 0; iex < trA.nExons - 1; iex++) {
+      if (trA.canonSJ[iex] == 0)
+        return;
+    };
+  } else if (P.outFilterIntronMotifs == "RemoveNoncanonicalUnannotated") {
+    for (uint iex = 0; iex < trA.nExons - 1; iex++) {
+      if (trA.canonSJ[iex] == 0 && trA.sjAnnot[iex] == 0)
+        return;
+    };
+  } else {
+    ostringstream errOut;
+    errOut << "EXITING because of FATAL INPUT error: unrecognized value of "
+      "--outFilterIntronMotifs="
+           << P.outFilterIntronMotifs << "\n";
+    errOut << "SOLUTION: re-run STAR with --outFilterIntronMotifs = None -OR- "
+      "RemoveNoncanonical -OR- RemoveNoncanonicalUnannotated\n";
+    exitWithError(errOut.str(), std::cerr, P.inOut->logMain,
+                  EXIT_CODE_INPUT_FILES, P);
+  };
+
+  { // check mapped length for each mate
+    uint nsj = 0, exl = 0;
+    for (uint iex = 0; iex < trA.nExons; iex++) { //
+      exl += trA.exons[iex][EX_L];
+      if (iex == trA.nExons - 1 ||
+          trA.canonSJ[iex] == -3) { // mate is completed, make the checks
+        if (nsj > 0 &&
+            (exl < P.alignSplicedMateMapLmin ||
+             exl < (uint)(P.alignSplicedMateMapLminOverLmate *
+                          RA->readLength[trA.exons[iex][EX_iFrag]]))) {
+          return; // do not record this transcript
+        };
+        exl = 0;
+        nsj = 0;
+      } else if (trA.canonSJ[iex] >= 0) {
+        nsj++;
+      };
+    };
+  };
+
+  if (P.outFilterBySJoutStage == 2) { // junctions have to be present in the filtered set P.sjnovel
+    for (uint iex = 0; iex < trA.nExons - 1; iex++) {
+      if (trA.canonSJ[iex] >= 0 && trA.sjAnnot[iex] == 0) {
+        uint jS = trA.exons[iex][EX_G] + trA.exons[iex][EX_L];
+        uint jE = trA.exons[iex + 1][EX_G] - 1;
+        if (binarySearch2(jS, jE, P.sjNovelStart, P.sjNovelEnd, P.sjNovelN) < 0)
+          return;
+      };
+    };
+  };
+
+  if (trA.exons[0][EX_iFrag] !=
+      trA.exons[trA.nExons - 1]
+      [EX_iFrag]) { // check for correct overlap between mates
+    if (trA.exons[trA.nExons - 1][EX_G] + trA.exons[trA.nExons - 1][EX_L] <=
+        trA.exons[0][EX_G])
+      return; // to avoid negative insert size
+    uint iexM2 = trA.nExons;
+    for (uint iex = 0; iex < trA.nExons - 1;
+         iex++) {                   // find the first exon of the second mate
+      if (trA.canonSJ[iex] == -3) { //
+        iexM2 = iex + 1;
+        break;
+      };
+    };
+
+    if (trA.exons[iexM2 - 1][EX_G] + trA.exons[iexM2 - 1][EX_L] >
+        trA.exons[iexM2]
+        [EX_G]) { // mates overlap - check consistency of junctions
+
+      if (trA.exons[0][EX_G] > trA.exons[iexM2][EX_G] + trA.exons[0][EX_R] +
+          P.alignEndsProtrude.nBasesMax)
+        return; // LeftMateStart > RightMateStart + allowance
+      if (trA.exons[iexM2 - 1][EX_G] + trA.exons[iexM2 - 1][EX_L] >
+          trA.exons[trA.nExons - 1][EX_G] + Lread -
+          trA.exons[trA.nExons - 1][EX_R] + P.alignEndsProtrude.nBasesMax)
+        return; // LeftMateEnd   > RightMateEnd +allowance
+
+      // check for junctions consistency
+      uint iex1 = 1, iex2 = iexM2 + 1; // last exons of the junction
+      for (; iex1 < iexM2;
+           iex1++) { // find first junction that overlaps 2nd mate
+        if (trA.exons[iex1][EX_G] >=
+            trA.exons[iex2 - 1][EX_G] + trA.exons[iex2 - 1][EX_L])
+          break;
+      };
+      while (iex1 < iexM2 &&
+             iex2 < trA.nExons) {        // cycle through all overlapping exons
+        if (trA.canonSJ[iex1 - 1] < 0) { // skip non-junctions
+          iex1++;
+          continue;
+        };
+        if (trA.canonSJ[iex2 - 1] < 0) { // skip non-junctions
+          iex2++;
+          continue;
+        };
+
+        if ((trA.exons[iex1][EX_G] != trA.exons[iex2][EX_G]) ||
+            ((trA.exons[iex1 - 1][EX_G] + trA.exons[iex1 - 1][EX_L]) !=
+             (trA.exons[iex2 - 1][EX_G] + trA.exons[iex2 - 1][EX_L]))) {
+          return; // inconsistent junctions on overlapping mates
+        };
+        iex1++;
+        iex2++;
+
+      }; // cycle through all overlapping exons
+    };   // mates overlap - check consistency of junctions
+  };     // check for correct overlap between mates
+
+  if (P.scoreGenomicLengthLog2scale != 0) { // add gap length score
+    Score += int(ceil(
+        log2((double)(trA.exons[trA.nExons - 1][EX_G] +
+                      trA.exons[trA.nExons - 1][EX_L] - trA.exons[0][EX_G])) *
+            P.scoreGenomicLengthLog2scale -
+        0.5));
+    Score = max(0, Score);
+  };
+
+  // calculate some final values for the transcript
+
+  trA.roStart = (trA.roStr == 0) ? trA.rStart : Lread - trA.rStart - trA.rLength;
+  trA.maxScore = Score;
+
+  if (trA.exons[0][EX_iFrag] ==
+      trA.exons[trA.nExons - 1][EX_iFrag]) { // mark single fragment transcripts
+    trA.iFrag = trA.exons[0][EX_iFrag];
+    RA->maxScoreMate[trA.iFrag] = max(RA->maxScoreMate[trA.iFrag], Score);
+  } else {
+    trA.iFrag = -1;
+  };
+
+  // Variation
+  Score += trA.variationAdjust(mapGen, R);
+
+  trA.maxScore = Score;
+
+  // transcript has been finalized, compare the score and record
+  if (Score + P.outFilterMultimapScoreRange >= wTr[0]->maxScore ||
+      (trA.iFrag >= 0 &&
+       Score + P.outFilterMultimapScoreRange >= RA->maxScoreMate[trA.iFrag]) ||
+      P.pCh.segmentMin > 0) {
+    // only record the transcripts within the window that are in the Score range
+    // OR within the score range of each mate
+    // OR all transcript if chimeric detection is activated
+
+    //             if (P.alignEndsType.in=="EndToEnd") {//check that the
+    //             alignment is end-to-end
+    //                 uint rTotal=trA.rLength+trA.lIns;
+    // //                 for (uint iex=1;iex<trA.nExons;iex++) {//find the
+    // inside exons
+    // // rTotal+=trA.exons[iex][EX_R]-trA.exons[iex-1][EX_R];
+    // //                 };
+    //                 if ( (trA.iFrag<0 &&
+    //                 rTotal<(RA->readLength[0]+RA->readLength[1])) ||
+    //                 (trA.iFrag>=0 && rTotal<RA->readLength[trA.iFrag]))
+    //                 return;
+    //             };
+
+    uint iTr = 0; // transcript insertion/replacement place
+
+    trA.mappedLength = 0;
+    for (uint iex = 0; iex < trA.nExons; iex++) { // caclulate total mapped length
+      trA.mappedLength += trA.exons[iex][EX_L];
+    };
+
+    while (iTr < *nWinTr) { // scan through all recorded transcripts for this
+                            // window - check for duplicates
+
+      // another way to calculate uOld, uNew: w/o gMap
+      uint nOverlap = blocksOverlap(trA, *wTr[iTr]);
+      uint uNew = trA.mappedLength - nOverlap;
+      uint uOld = wTr[iTr]->mappedLength - nOverlap;
+
+      if (uNew == 0 && Score < wTr[iTr]->maxScore) { // new transript is a subset of the old ones
+        break;
+      } else if (uOld == 0) { // old transcript is a subset of the new one,
+                              // remove old transcript
+        Transcript *pTr = wTr[iTr];
+        for (uint ii = iTr + 1; ii < *nWinTr; ii++)
+          wTr[ii - 1] = wTr[ii]; // shift transcripts
+        (*nWinTr)--;
+        wTr[*nWinTr] = pTr;
+      } else if (uOld > 0 &&
+                 (uNew > 0 ||
+                  Score >= wTr[iTr]->maxScore)) { // check next transcript
+        iTr++;
+      };
+    };
+
+    if (iTr == *nWinTr) {                   // insert the new transcript
+      for (iTr = 0; iTr < *nWinTr; iTr++) { // find inseriton location
+        if (Score > wTr[iTr]->maxScore ||
+            (Score == wTr[iTr]->maxScore && trA.gLength < wTr[iTr]->gLength))
+          break;
+      };
+
+      Transcript *pTr = wTr[*nWinTr];
+      for (int ii = *nWinTr; ii > int(iTr); ii--) { // shift all the transcript pointers down from iTr
+        wTr[ii] = wTr[ii - 1];
+      };
+      wTr[iTr] = pTr; // the new transcript pointer is now at *nWinTr+1, move it
+                      // into the iTr
+      *(wTr[iTr]) = trA;
+      if (*nWinTr < P.alignTranscriptsPerWindowNmax) {
+        (*nWinTr)++; // increment number of transcripts per window;
+      } else {
+        //"WARNING: too many recorded transcripts per window:
+        // iRead="<<RA->iRead<< "\n";
+      };
+    };
+  };
+
+  return;
+}
+
 void stitchWindowAligns(uint iA, uint nA, int Score, bool WAincl[], uint tR2, uint tG2, Transcript trA, \
                         uint Lread, uiWA* WA, char* R, Genome &mapGen, \
                         Parameters& P, Transcript** wTr, uint* nWinTr, ReadAlign *RA) {
@@ -14,297 +382,8 @@ void stitchWindowAligns(uint iA, uint nA, int Score, bool WAincl[], uint tR2, ui
     if (iA>=nA && tR2==0) return; //no aligns in the transcript
 
     if (iA>=nA) {//no more aligns to add, finalize the transcript
-
-        //extend first
-        Transcript trAstep1;
-
-        int vOrder[2]; //decide in which order to extend: extend the 5' of the read first
-
-        #if EXTEND_ORDER==1
-        if ( trA.roStr==0 ) {//decide in which order to extend: extend the 5' of the read first
-            vOrder[0]=0; vOrder[1]=1;
-        } else {
-            vOrder[0]=1; vOrder[1]=0;
-        };
-        #elif EXTEND_ORDER==2
-            vOrder[0]=0; vOrder[1]=1;
-        #else
-            #error "EXTEND_ORDER value unrecognized"
-        #endif
-
-        for (int iOrd=0;iOrd<2;iOrd++) {
-
-            switch (vOrder[iOrd]) {
-
-            case 0: //extend at start
-
-            if (trA.rStart>0) {// if transcript does not start at base, extend to the read start
-                trAstep1.reset();
-                uint imate=trA.exons[0][EX_iFrag];
-                if ( extendAlign(R, mapGen.G, trA.rStart-1, trA.gStart-1, -1, -1, trA.rStart, tR2-trA.rStart+1, \
-                                 trA.nMM, RA->outFilterMismatchNmaxTotal, P.outFilterMismatchNoverLmax, \
-                                 P.alignEndsType.ext[imate][(int)(trA.Str!=imate)], &trAstep1) ) {//if could extend
-
-                    trA.add(&trAstep1);
-                    Score += trAstep1.maxScore;
-
-                    trA.exons[0][EX_R] = trA.rStart = trA.rStart - trAstep1.extendL;
-                    trA.exons[0][EX_G] = trA.gStart = trA.gStart - trAstep1.extendL;
-                    trA.exons[0][EX_L] += trAstep1.extendL;
-
-                };
-            //TODO penalize the unmapped bases at the start
-            };
-            break;
-
-            case 1: //extend at end
-
-            if ( tR2<Lread ) {//extend alignment to the read end
-                trAstep1.reset();
-                uint imate=trA.exons[trA.nExons-1][EX_iFrag];
-                if ( extendAlign(R, mapGen.G, tR2+1, tG2+1, +1, +1, Lread-tR2-1, tR2-trA.rStart+1, \
-                                 trA.nMM, RA->outFilterMismatchNmaxTotal,  P.outFilterMismatchNoverLmax, \
-                                 P.alignEndsType.ext[imate][(int)(imate==trA.Str)], &trAstep1) ) {//if could extend
-
-                    trA.add(&trAstep1);
-                    Score += trAstep1.maxScore;
-
-                    tR2 += trAstep1.extendL;
-                    tG2 += trAstep1.extendL;
-
-                    trA.exons[trA.nExons-1][EX_L] += trAstep1.extendL;//extend the length of the last exon
-
-                };
-            //TODO penalize unmapped bases at the end
-            };
-        };
-        };
-
-        if (!P.alignSoftClipAtReferenceEnds.yes &&  \
-                ( (trA.exons[trA.nExons-1][EX_G] + Lread-trA.exons[trA.nExons-1][EX_R]) > (mapGen.chrStart[trA.Chr]+mapGen.chrLength[trA.Chr]) || \
-                   trA.exons[0][EX_G]<(mapGen.chrStart[trA.Chr]+trA.exons[0][EX_R]) ) ) {
-            return; //no soft clipping past the ends of the chromosome
-        };
-
-
-        trA.rLength = 0;
-        for (uint isj=0;isj<trA.nExons;isj++) {
-            trA.rLength += trA.exons[isj][EX_L];
-        };
-        trA.gLength = tG2+1-trA.gStart;
-
-        //check exons lengths including repeats, do not report a transcript with short exons
-        for (uint isj=0;isj<trA.nExons-1;isj++) {//check exons for min length, if they are not annotated and precede a junction
-            if ( trA.canonSJ[isj]>=0 ) {//junction
-                if (trA.sjAnnot[isj]==1) {//sjdb
-                    if (  ( trA.exons[isj][EX_L]   < P.alignSJDBoverhangMin && (isj==0            || trA.canonSJ[isj-1]==-3 || (trA.sjAnnot[isj-1]==0 && trA.canonSJ[isj-1]>=0) ) )\
-                       || ( trA.exons[isj+1][EX_L] < P.alignSJDBoverhangMin && (isj==trA.nExons-2 || trA.canonSJ[isj+1]==-3 || (trA.sjAnnot[isj+1]==0 && trA.canonSJ[isj+1]>=0) ) ) )return;
-                } else {//non-sjdb
-                    if (  trA.exons[isj][EX_L] < P.alignSJoverhangMin + trA.shiftSJ[isj][0] \
-                       || trA.exons[isj+1][EX_L] < P.alignSJoverhangMin + trA.shiftSJ[isj][1]   ) return;
-                };
-            };
-        };
-        if (trA.nExons>1 && trA.sjAnnot[trA.nExons-2]==1 && trA.exons[trA.nExons-1][EX_L] < P.alignSJDBoverhangMin) return; //this exon was not checkedin the cycle above
-
-        //filter strand consistency
-        uint sjN=0;
-        trA.intronMotifs[0]=0;trA.intronMotifs[1]=0;trA.intronMotifs[2]=0;
-        trA.sjYes=false;
-        for (uint iex=0;iex<trA.nExons-1;iex++) {
-            if (trA.canonSJ[iex]>=0)
-            {//junctions - others are indels
-                sjN++;
-                trA.intronMotifs[trA.sjStr[iex]]++;
-                trA.sjYes=true;
-            };
-        };
-
-        if (trA.intronMotifs[1]>0 && trA.intronMotifs[2]==0)
-            trA.sjMotifStrand=1;
-        else if (trA.intronMotifs[1]==0 && trA.intronMotifs[2]>0)
-            trA.sjMotifStrand=2;
-        else
-            trA.sjMotifStrand=0;
-
-        if (trA.intronMotifs[1]>0 && trA.intronMotifs[2]>0 && P.outFilterIntronStrands=="RemoveInconsistentStrands")
-                return;
-
-        if (sjN>0 && trA.sjMotifStrand==0 && P.outSAMstrandField.type==1) {//strand not defined for a junction
-            return;
-        };
-
-        if (P.outFilterIntronMotifs=="None") {//no filtering
-
-        } else if (P.outFilterIntronMotifs=="RemoveNoncanonical") {
-            for (uint iex=0;iex<trA.nExons-1;iex++) {
-                if (trA.canonSJ[iex]==0) return;
-            };
-        } else if (P.outFilterIntronMotifs=="RemoveNoncanonicalUnannotated") {
-            for (uint iex=0;iex<trA.nExons-1;iex++) {
-                if (trA.canonSJ[iex]==0 && trA.sjAnnot[iex]==0) return;
-            };
-        } else {
-            ostringstream errOut;
-            errOut << "EXITING because of FATAL INPUT error: unrecognized value of --outFilterIntronMotifs=" <<P.outFilterIntronMotifs <<"\n";
-            errOut << "SOLUTION: re-run STAR with --outFilterIntronMotifs = None -OR- RemoveNoncanonical -OR- RemoveNoncanonicalUnannotated\n";
-            exitWithError(errOut.str(),std::cerr, P.inOut->logMain, EXIT_CODE_INPUT_FILES, P);
-        };
-
-        {//check mapped length for each mate
-            uint nsj=0,exl=0;
-            for (uint iex=0;iex<trA.nExons;iex++) {//
-                exl+=trA.exons[iex][EX_L];
-                if (iex==trA.nExons-1 || trA.canonSJ[iex]==-3) {//mate is completed, make the checks
-                    if (nsj>0 && (exl<P.alignSplicedMateMapLmin || exl < (uint) (P.alignSplicedMateMapLminOverLmate*RA->readLength[trA.exons[iex][EX_iFrag]])) ) {
-                        return; //do not record this transcript
-                    };
-                    exl=0;nsj=0;
-                } else if (trA.canonSJ[iex]>=0) {
-                    nsj++;
-                };
-            };
-        };
-
-        if (P.outFilterBySJoutStage==2) {//junctions have to be present in the filtered set P.sjnovel
-            for (uint iex=0;iex<trA.nExons-1;iex++) {
-                if (trA.canonSJ[iex]>=0 && trA.sjAnnot[iex]==0) {
-                    uint jS=trA.exons[iex][EX_G]+trA.exons[iex][EX_L];
-                    uint jE=trA.exons[iex+1][EX_G]-1;
-                    if ( binarySearch2(jS,jE,P.sjNovelStart,P.sjNovelEnd,P.sjNovelN) < 0 ) return;
-                };
-            };
-        };
-
-        if ( trA.exons[0][EX_iFrag]!=trA.exons[trA.nExons-1][EX_iFrag] ) {//check for correct overlap between mates
-            if (trA.exons[trA.nExons-1][EX_G]+trA.exons[trA.nExons-1][EX_L] <= trA.exons[0][EX_G]) return; //to avoid negative insert size
-            uint iexM2=trA.nExons;
-            for (uint iex=0;iex<trA.nExons-1;iex++) {//find the first exon of the second mate
-                if (trA.canonSJ[iex]==-3) {//
-                    iexM2=iex+1;
-                    break;
-                };
-            };
-
-            if ( trA.exons[iexM2-1][EX_G] + trA.exons[iexM2-1][EX_L] > trA.exons[iexM2][EX_G] ) {//mates overlap - check consistency of junctions
-
-                if (trA.exons[0][EX_G] > \
-                    trA.exons[iexM2][EX_G]+trA.exons[0][EX_R]+P.alignEndsProtrude.nBasesMax) return; //LeftMateStart > RightMateStart + allowance
-                if (trA.exons[iexM2-1][EX_G]+trA.exons[iexM2-1][EX_L] > \
-                   trA.exons[trA.nExons-1][EX_G]+Lread-trA.exons[trA.nExons-1][EX_R]+P.alignEndsProtrude.nBasesMax) return; //LeftMateEnd   > RightMateEnd +allowance
-
-                //check for junctions consistency
-                uint iex1=1, iex2=iexM2+1; //last exons of the junction
-                for  (; iex1<iexM2; iex1++) {//find first junction that overlaps 2nd mate
-                    if (trA.exons[iex1][EX_G] >= trA.exons[iex2-1][EX_G] + trA.exons[iex2-1][EX_L]) break;
-                };
-                while (iex1<iexM2 && iex2<trA.nExons) {//cycle through all overlapping exons
-                    if (trA.canonSJ[iex1-1]<0) {//skip non-junctions
-                        iex1++;
-                        continue;
-                    };
-                    if (trA.canonSJ[iex2-1]<0) {//skip non-junctions
-                        iex2++;
-                        continue;
-                    };
-
-                    if ( ( trA.exons[iex1][EX_G]!=trA.exons[iex2][EX_G] ) || ( (trA.exons[iex1-1][EX_G]+trA.exons[iex1-1][EX_L]) != (trA.exons[iex2-1][EX_G]+trA.exons[iex2-1][EX_L]) ) ) {
-                        return; //inconsistent junctions on overlapping mates
-                    };
-                    iex1++;
-                    iex2++;
-
-                };//cycle through all overlapping exons
-            };//mates overlap - check consistency of junctions
-        };//check for correct overlap between mates
-
-        if (P.scoreGenomicLengthLog2scale!=0) {//add gap length score
-            Score += int(ceil( log2( (double) ( trA.exons[trA.nExons-1][EX_G]+trA.exons[trA.nExons-1][EX_L] - trA.exons[0][EX_G]) ) \
-                     * P.scoreGenomicLengthLog2scale - 0.5));
-            Score = max(0,Score);
-        };
-
-        //calculate some final values for the transcript
-
-        trA.roStart = (trA.roStr == 0) ? trA.rStart : Lread - trA.rStart - trA.rLength;
-        trA.maxScore=Score;
-
-        if (trA.exons[0][EX_iFrag]==trA.exons[trA.nExons-1][EX_iFrag]) {//mark single fragment transcripts
-            trA.iFrag=trA.exons[0][EX_iFrag];
-            RA->maxScoreMate[trA.iFrag] = max (RA->maxScoreMate[trA.iFrag] , Score);
-        } else {
-            trA.iFrag=-1;
-        };
-
-        //Variation
-        Score+=trA.variationAdjust(mapGen, R);
-
-        trA.maxScore=Score;
-
-        // transcript has been finalized, compare the score and record
-        if (       Score+P.outFilterMultimapScoreRange >= wTr[0]->maxScore \
-                || ( trA.iFrag>=0 && Score+P.outFilterMultimapScoreRange >= RA->maxScoreMate[trA.iFrag] ) \
-                || P.pCh.segmentMin>0) {
-                //only record the transcripts within the window that are in the Score range
-                //OR within the score range of each mate
-                //OR all transcript if chimeric detection is activated
-
-//             if (P.alignEndsType.in=="EndToEnd") {//check that the alignment is end-to-end
-//                 uint rTotal=trA.rLength+trA.lIns;
-// //                 for (uint iex=1;iex<trA.nExons;iex++) {//find the inside exons
-// //                     rTotal+=trA.exons[iex][EX_R]-trA.exons[iex-1][EX_R];
-// //                 };
-//                 if ( (trA.iFrag<0 && rTotal<(RA->readLength[0]+RA->readLength[1])) || (trA.iFrag>=0 && rTotal<RA->readLength[trA.iFrag])) return;
-//             };
-
-            uint iTr=0; //transcript insertion/replacement place
-
-            trA.mappedLength=0;
-            for (uint iex=0;iex<trA.nExons;iex++) {//caclulate total mapped length
-                trA.mappedLength += trA.exons[iex][EX_L];
-            };
-
-            while (iTr < *nWinTr) {//scan through all recorded transcripts for this window - check for duplicates
-
-                //another way to calculate uOld, uNew: w/o gMap
-                uint nOverlap=blocksOverlap(trA,*wTr[iTr]);
-                uint uNew=trA.mappedLength-nOverlap;
-                uint uOld=wTr[iTr]->mappedLength-nOverlap;
-
-                if (uNew==0 && Score < wTr[iTr]->maxScore) {//new transript is a subset of the old ones
-                    break;
-                } else if (uOld==0) {//old transcript is a subset of the new one, remove old transcript
-                    Transcript *pTr=wTr[iTr];
-                    for  (uint ii=iTr+1;ii<*nWinTr;ii++) wTr[ii-1]=wTr[ii]; //shift transcripts
-                    (*nWinTr)--;
-                    wTr[*nWinTr]=pTr;
-                } else if (uOld>0 && (uNew>0 || Score >= wTr[iTr]->maxScore) ) {//check next transcript
-                    iTr++;
-                };
-
-            };
-
-            if (iTr==*nWinTr) {//insert the new transcript
-                for (iTr=0;iTr<*nWinTr;iTr++) {//find inseriton location
-                    if (Score>wTr[iTr]->maxScore || (Score==wTr[iTr]->maxScore && trA.gLength<wTr[iTr]->gLength) ) break;
-                };
-
-                Transcript *pTr=wTr[*nWinTr];
-                for (int ii=*nWinTr; ii> int(iTr); ii--) {//shift all the transcript pointers down from iTr
-                    wTr[ii]=wTr[ii-1];
-                };
-                wTr[iTr]=pTr; //the new transcript pointer is now at *nWinTr+1, move it into the iTr
-                *(wTr[iTr])=trA;
-                if (*nWinTr<P.alignTranscriptsPerWindowNmax) {
-                    (*nWinTr)++; //increment number of transcripts per window;
-                } else {
-                        //"WARNING: too many recorded transcripts per window: iRead="<<RA->iRead<< "\n";
-                };
-            };
-        };
-
-
-        return;
+      finalizeTranscript(RA, wTr, nWinTr, P, mapGen, R, Lread, trA, tG2, tR2, Score);
+      return;
     };
 
     ///////////////////////////////////////////////////////////////////////////////////

--- a/source/stitchWindowAligns.h
+++ b/source/stitchWindowAligns.h
@@ -1,12 +1,13 @@
 #include "IncludeDefine.h"
 #include "Parameters.h"
+#include "ReadAlign.h"
 #include "Transcript.h"
 #include "extendAlign.h"
 #include "stitchAlignToTranscript.h"
-#include "ReadAlign.h"
 
-void stitchWindowAligns(uint iA, uint nA, int Score, bool WAincl[], uint tR2, uint tG2, Transcript trA, \
-                        uint Lread, uiWA* WA, char* R, Genome &mapGen, \
-                        Parameters& P, Transcript** wTr, uint* nWinTr, ReadAlign *RA);
-    //recursively stitch aligns for one gene
-    //*nWinTr - number of transcripts for the current window
+void stitchWindowAligns(uint iA, uint nA, int Score, bool WAincl[], uint tR2,
+                        uint tG2, const Transcript &trA, uint Lread, uiWA *WA,
+                        char *R, const Genome &mapGen, const Parameters &P,
+                        Transcript **wTr, uint *nWinTr, ReadAlign *RA);
+// recursively stitch aligns for one gene
+//*nWinTr - number of transcripts for the current window

--- a/source/stitchWindowAligns.h
+++ b/source/stitchWindowAligns.h
@@ -6,8 +6,8 @@
 #include "stitchAlignToTranscript.h"
 
 void stitchWindowAligns(uint iA, uint nA, int Score, bool WAincl[], uint tR2,
-                        uint tG2, const Transcript &trA, uint Lread, uiWA *WA,
-                        char *R, const Genome &mapGen, const Parameters &P,
+                        uint tG2, const Transcript &trA, uint Lread, const uiWA *WA,
+                        const char *R, const Genome &mapGen, const Parameters &P,
                         Transcript **wTr, uint *nWinTr, ReadAlign *RA);
 // recursively stitch aligns for one gene
 //*nWinTr - number of transcripts for the current window


### PR DESCRIPTION
During mapping, `stitchWindowAligns` uses recursive calls
1) one using the current alignment `iA`
2) one not using.

The call 1) is performed only if `stitchAlignToTranscript` does not return a bad score.
Since `stitchAlignToTranscript` modifies the `Transcript` object, an additional copy is created, which is expansive.

This pull request attempts to address this performance overhead:
additional cheaper check is performed, which allows to avoid copy-creation of a new `Transcript` object if it will not be used in the recursion.

The changes comprise of 
- adding const modifiers
- extracting a function for transcript finalization (no code modified)
- [new function](https://github.com/alexey0308/STAR/blob/2395ee1cda55b15972d75d477197fe99fbe548c9/source/stitchWindowAligns.cpp#L10) for checking if this alignment can be skipped, used [here](https://github.com/alexey0308/STAR/blob/2395ee1cda55b15972d75d477197fe99fbe548c9/source/stitchWindowAligns.cpp#L421)
- formatting, e.g. long lines of code are split.

Progress output with and without the PR code on a test subset:
```
           Time    Speed        Read     Read   Mapped   Mapped   Mapped   Mapped Unmapped Unmapped Unmapped Unmapped
                    M/hr      number   length   unique   length   MMrate    multi   multi+       MM    short    other
Nov 02 13:11:28    117.1     2113669      101    94.3%    100.4     0.6%     2.5%     0.1%     0.0%     3.0%     0.0%
ALL DONE!
           Time    Speed        Read     Read   Mapped   Mapped   Mapped   Mapped Unmapped Unmapped Unmapped Unmapped
                    M/hr      number   length   unique   length   MMrate    multi   multi+       MM    short    other
Nov 02 13:13:09     49.5     1168327      101    94.3%    100.4     0.6%     2.6%     0.1%     0.0%     3.0%     0.0%
ALL DONE!
```
