### PR TITLE
Mapping speed improvement

### DIFF
--- a/source/FastResetVector.h
+++ b/source/FastResetVector.h
@@ -1,0 +1,40 @@
+#ifndef H_FastResetVector
+#define H_FastResetVector
+
+#include <vector>
+
+// Implementation of a vector that can be reset to a default value in ~O(1).
+// It is more efficient than an ordinary vector if:
+// - the values are sparse, such that only a few elements need to be deleted.
+// - there are not too many accesses to elements, since upon each access
+//   it must be checked if the element is stale.
+
+template <class T> class FastResetVector {
+
+    private:
+        vector<T> data; // contains actual data to be stored
+        T defaultValue; // all elements of `data` are initialized with this value
+        unsigned int incarnation = 0; // increasing the incarnation invalidates all elements of `data` (=reset)
+        vector<unsigned int> lastUpdate; // for each element in `data`, keep track of the incarnation that it was last updated
+
+    public:
+        FastResetVector(const size_t s, const T& d): data(s,d), defaultValue(d), lastUpdate(s) {}
+
+        inline T& operator[](const size_t i) { // whenever an element is accessed, check if it's stale
+            if (incarnation != lastUpdate[i]) { // is it stale?
+                data[i] = defaultValue; // reset to defaut value
+                lastUpdate[i] = incarnation; // mark as fresh for this incarnation
+            };
+            return data[i];
+        }
+
+        void reset() {
+            incarnation++; // we can invalidate `data` simply through "reincarnation"
+            if (incarnation == 0) // only when there is an integer overflow, we need to reinitialize
+                fill(data.begin(), data.end(), defaultValue);
+        }
+
+};
+
+#endif
+

--- a/source/PackedArray.h
+++ b/source/PackedArray.h
@@ -27,7 +27,8 @@ inline uint PackedArray::operator [] (uint ii) {
    uint S=b%8;
 
    uint a1 = *((uint*) (charArray+B));
-   a1 = ((a1>>S)<<wordCompLength)>>wordCompLength;
+   a1 >>= S;
+   a1 &= bitRecMask;
    return a1;
 };
 

--- a/source/ReadAlign.cpp
+++ b/source/ReadAlign.cpp
@@ -7,11 +7,7 @@ ReadAlign::ReadAlign (Parameters& Pin, Genome &genomeIn, Transcriptome *TrIn, in
                     : mapGen(genomeIn), P(Pin), chunkTr(TrIn)
 {
     readNmates=P.readNmates;
-    winBin = new uintWinBin* [2];
-    winBin[0] = new uintWinBin [P.winBinN];
-    winBin[1] = new uintWinBin [P.winBinN];
-    memset(winBin[0],255,sizeof(winBin[0][0])*P.winBinN);
-    memset(winBin[1],255,sizeof(winBin[0][0])*P.winBinN);
+    winBin.resize(2, FastResetVector<uintWinBin>(P.winBinN, uintWinBinMax));
     //RNGs
     rngMultOrder.seed(P.runRNGseed*(iChunk+1));
     rngUniformReal0to1=std::uniform_real_distribution<double> (0.0, 1.0);

--- a/source/ReadAlign.h
+++ b/source/ReadAlign.h
@@ -13,6 +13,7 @@
 #include "ChimericDetection.h"
 #include "SoloRead.h"
 #include "ReadAnnotations.h"
+#include "FastResetVector.h"
 
 #include <time.h>
 #include <random>
@@ -111,7 +112,7 @@ class ReadAlign {
 //         uint fragLength[MAX_N_FRAG], fragStart[MAX_N_FRAG]; //fragment Lengths and Starts in read space
 
         //binned alignments
-        uintWinBin **winBin; //binned genome: window ID (number) per bin
+        vector< FastResetVector<uintWinBin> > winBin; //binned genome: window ID (number) per bin
 
         //alignments
         uiPC *PC; //pieces coordinates

--- a/source/ReadAlign_createExtendWindowsWithAlign.cpp
+++ b/source/ReadAlign_createExtendWindowsWithAlign.cpp
@@ -9,7 +9,7 @@ int ReadAlign::createExtendWindowsWithAlign(uint a1, uint aStr) {
 
     uint aBin = (a1 >> P.winBinNbits); //align's bin
     uint iBinLeft=aBin, iBinRight=aBin;
-    uintWinBin* wB=winBin[aStr];
+    FastResetVector<uintWinBin>& wB=winBin[aStr];
     uint iBin=-1, iWin=-1, iWinRight=-1;
 
 

--- a/source/ReadAlign_stitchPieces.cpp
+++ b/source/ReadAlign_stitchPieces.cpp
@@ -13,9 +13,8 @@
 void ReadAlign::stitchPieces(char **R, uint Lread) {
 
     //zero-out winBin
-    memset(winBin[0],255,sizeof(winBin[0][0])*P.winBinN);
-    memset(winBin[1],255,sizeof(winBin[0][0])*P.winBinN);
-
+    winBin[0].reset();
+    winBin[1].reset();
 
 //     for (uint iWin=0;iWin<nWall;iWin++) {//zero out winBin
 //         if (WC[iWin][WC_gStart]<=WC[iWin][WC_gEnd]) {//otherwise the window is dead


### PR DESCRIPTION
Hi Alex,

This is a proposal for a mapping speed improvement. It is independent of the improvement suggested by alexey0308 and boosts the throughput by 10-25% - depending on the operating system / compiler version / CPU. I benchmarked it on two systems with human data:
* Ubuntu 19.10 / GCC v9.2.1 / Intel Xeon E5-2660 2.0GHz
* CentOS 7.4 / GCC v4.8.5 / AMD Opteron 23xx Gen3 2.1GHz.

I could not benchmark it on a Mac. This might be of interest, however, because `memset` is supposedly very efficient on MacOS.

Here are the essentials: `stitchPieces` wastes a lot of time resetting the `winBin` array using `memset`. With every call, it rewrites ~200kb of memory, although typically only a few hundred bytes of the array are accessed. I replaced `winBin` with a "smart" vector that only resets the elements that are actually accessed (`FastResetVector`). You pay a little bit of overhead with every access to an element, because upon each access the vector needs to check if the element being accessed is stale. But you avoid having to rewrite the whole vector. This pays off when the vector is sparse (as is the case with `winBin`) and when there are not too many accesses to the vector. Or stated the other way around: This implementation would be detrimental to performance when many elements of `winBin` would be written/read. According to my measurements there are typically only a few hundred. I'm curious, though, whether there could be a scenario where `winBin` is heavily accessed. I noticed that `alignWindowsPerReadNmax` is set to `10000` by default. Under what circumstances would this limit be reached? In my tests it barely even reached 100 and only with a few reads. Let me know what you think. I lack the overview to judge if my suggested patch would be infeasible in some settings.

There is a second (minor) code optimization: The `operator[]()` function of `PackedArray` seems to be a code hot spot. The bit shifting in this line turns out to be the most expensive: `a1 = ((a1>>S)<<wordCompLength)>>wordCompLength;`. It can easily be replaced with a bit mask operation. I did not really think that it would make a difference, but it does. The effect is a bit hard to measure, but taking the median of ten runs of STAR with/without the optimization confirmed a 1-2% performance improvement.

Regards,
Sebastian