### PR TITLE
report multi-mapping chimeric reads in BAM format

### DIFF
--- a/source/BAMfunctions.cpp
+++ b/source/BAMfunctions.cpp
@@ -59,9 +59,10 @@ int bam_read1_fromArray(char *bamChar, bam1_t *b) //modified from samtools bam_r
 	if (b->m_data < b->l_data) {
 		b->m_data = b->l_data;
 		kroundup32(b->m_data);
-		b->data = (uint8_t*)realloc(b->data, b->m_data);
-		if (!b->data)
-			return -4;
+// no need to realloc b->data, because it is overwritten later with bamChar
+//		b->data = (uint8_t*)realloc(b->data, b->m_data);
+//		if (!b->data)
+//			return -4;
 	}
 // // 	if (bgzf_read(fp, b->data, b->l_data) != b->l_data) return -4;
 // // 	//b->l_aux = b->l_data - c->n_cigar * 4 - c->l_qname - c->l_qseq - (c->l_qseq+1)/2;

--- a/source/ChimericAlign.cpp
+++ b/source/ChimericAlign.cpp
@@ -1,7 +1,7 @@
 #include "ChimericAlign.h"
 
 ChimericAlign::ChimericAlign(ChimericSegment &seg1in, ChimericSegment &seg2in, int chimScoreIn, Genome &genomeIn, ReadAlign *RAin)
-                              : seg1(seg1in), seg2(seg2in),chimScore(chimScoreIn), P(seg1in.P), pCh(P.pCh), mapGen(genomeIn), RA(RAin) {
+                              : seg1(seg1in), seg2(seg2in),chimScore(chimScoreIn), RA(RAin), P(seg1in.P), pCh(P.pCh), mapGen(genomeIn) {
     stitchingDone=false;
 
     al1=&seg1.align;

--- a/source/ChimericAlign.h
+++ b/source/ChimericAlign.h
@@ -24,16 +24,17 @@ class ChimericAlign
 
         ChimericAlign(ChimericSegment &seg1in, ChimericSegment &seg2in, int chimScoreIn, Genome &genomeIn, ReadAlign *RAin); //allocate
         void chimericJunctionOutput(fstream &outStream, uint chimN, int maxNonChimAlignScore, bool PEmerged_flag, int chimScoreBest, int maxPossibleAlignScore);
+        static void chimericBAMoutput(Transcript *al1, Transcript *al2, ReadAlign *RA, const uint iTr, const uint chimN, const bool isBestChimAlign, const Parameters& P);
         void chimericStitching(char *genSeq, char **Read1);
         bool chimericCheck();
 
         bool stitchingDone;
 
+        ReadAlign *RA;
     private:
         Parameters &P;
         ParametersChimeric &pCh;
         Genome &mapGen;
-        ReadAlign *RA;
 
 };
 

--- a/source/ChimericAlign_chimericBAMoutput.cpp
+++ b/source/ChimericAlign_chimericBAMoutput.cpp
@@ -95,6 +95,7 @@ void ChimericAlign::chimericBAMoutput(Transcript *al1, Transcript *al2, ReadAlig
             memcpy( (void*) (RA->outBAMoneAlign[ii]+RA->outBAMoneAlignNbytes[ii]), tagSA1.c_str(), tagSA1.size()+1);//copy string including \0 at the end
             RA->outBAMoneAlignNbytes[ii]+=tagSA1.size()+1;
              * ( (uint32*) RA->outBAMoneAlign[ii] ) = RA->outBAMoneAlignNbytes[ii]-sizeof(uint32);
+	    free(b); // don't use bam_destroy1(), because bam_read1_fromArray does not allocate memory for b->data
         };
 
         if (P.outBAMunsorted) RA->outBAMunsorted->unsortedOneAlign(RA->outBAMoneAlign[ii], RA->outBAMoneAlignNbytes[ii], ii>0 ? 0 : bamBytesTotal);

--- a/source/ChimericAlign_chimericBAMoutput.cpp
+++ b/source/ChimericAlign_chimericBAMoutput.cpp
@@ -1,0 +1,104 @@
+#include "ChimericAlign.h"
+#include "ReadAlign.h"
+#include "BAMfunctions.h"
+
+#include <vector>
+
+void ChimericAlign::chimericBAMoutput(Transcript *al1, Transcript *al2, ReadAlign *RA, const uint iTr, const uint chimN, const bool isBestChimAlign, const Parameters& P)
+{
+    vector<Transcript*> trChim(2);
+    trChim[0] = al1;
+    trChim[1] = al2;
+
+    int chimRepresent=-999, chimType=0;
+    if (trChim[0]->exons[0][EX_iFrag]!=trChim[0]->exons[trChim[0]->nExons-1][EX_iFrag]) {//tr0 has both mates
+        chimRepresent = 0;
+        chimType = 1;
+    } else if (trChim[1]->exons[0][EX_iFrag]!=trChim[1]->exons[trChim[1]->nExons-1][EX_iFrag]) {//tr1 has both mates
+        chimRepresent = 1;
+        chimType = 1;
+    } else if (trChim[0]->exons[0][EX_iFrag]!=trChim[1]->exons[0][EX_iFrag]) {//tr0 and tr1 are single different mates
+        chimRepresent = -1;
+        chimType = 2;
+    } else  {//two chimeric segments are on the same mate - this can only happen for single-end reads
+        chimRepresent = (trChim[0]->maxScore > trChim[1]->maxScore) ? 0 : 1;
+        chimType = 3;
+    };
+
+    int alignType, bamN=0, bamIsuppl=-1, bamIrepr=-1;
+    uint bamBytesTotal=0;//estimate of the total size of all bam records, for output buffering
+    uint mateChr,mateStart;
+    uint8_t mateStrand;
+    for (uint itr=0;itr<trChim.size();itr++) {//generate bam for all chimeric pieces
+        trChim[itr]->primaryFlag=isBestChimAlign;
+        if (chimType==2) {//PE, encompassing
+            mateChr=trChim[1-itr]->Chr;
+            mateStart=trChim[1-itr]->exons[0][EX_G];
+            mateStrand=(uint8_t) (trChim[1-itr]->Str!=trChim[1-itr]->exons[0][EX_iFrag]);
+            alignType=-10;
+        } else {//spanning chimeric alignment, could be PE or SE
+            mateChr=-1;mateStart=-1;mateStrand=0;//no need fot mate info unless this is the supplementary alignment
+            if (chimRepresent==(int)itr) {
+                alignType=-10; //this is representative part of chimeric alignment, record is as normal; if encompassing chimeric junction, both are recorded as normal
+                bamIrepr=bamN;
+                if (trChim[itr]->exons[0][EX_iFrag]!=trChim[1-itr]->exons[0][EX_iFrag]) {//the next mate is chimerically split
+                    ++bamIrepr;
+                };
+//TODO check flags of SE split read
+//                if (chimType==3) {
+//                    bamIrepr=bamN;
+//                } else if (trChim[itr]->exons[0][EX_iFrag]==trChim[1-itr]->exons[0][EX_iFrag]) {
+//
+//                };
+//                bamIrepr=( (itr%2)==(trChim[itr]->Str) && chimType!=3) ? bamN+1 : bamN;//this is the mate that is chimerically split
+            } else {//"supplementary" chimeric segment
+                alignType=P.pCh.out.bamHardClip ? ( ( itr%2==trChim[itr]->Str ) ? -12 : -11) : -13 ; //right:left chimeric junction
+                bamIsuppl=bamN;
+                if (chimType==1) {//PE alignment, need mate info for the suppl
+                    uint iex=0;
+                    for (;iex<trChim[chimRepresent]->nExons-1;iex++) {
+                        if (trChim[chimRepresent]->exons[iex][EX_iFrag]!=trChim[itr]->exons[0][EX_iFrag]) {
+                            break;
+                        };
+                    };
+                    mateChr=trChim[chimRepresent]->Chr;
+                    mateStart=trChim[chimRepresent]->exons[iex][EX_G];
+                    mateStrand=(uint8_t) (trChim[chimRepresent]->Str!=trChim[chimRepresent]->exons[iex][EX_iFrag]);
+                };
+            };
+
+        };
+
+        bamN+=RA->alignBAM(*trChim[itr], chimN, iTr, RA->mapGen.chrStart[trChim[itr]->Chr],  mateChr, \
+                           mateStart-RA->mapGen.chrStart[(mateChr<RA->mapGen.nChrReal ? mateChr : 0)], mateStrand, alignType, \
+                           NULL, P.outSAMattrOrder, RA->outBAMoneAlign+bamN, RA->outBAMoneAlignNbytes+bamN);
+        bamBytesTotal+=RA->outBAMoneAlignNbytes[0]+RA->outBAMoneAlignNbytes[1];//outBAMoneAlignNbytes[1] = 0 if SE is recorded
+    };
+
+    //write all bam lines
+    for (int ii=0; ii<bamN; ii++) {//output all pieces
+        int tagI=-1;
+        if (ii==bamIrepr) {
+            tagI=bamIsuppl;
+        } else if (ii==bamIsuppl) {
+            tagI=bamIrepr;
+        };
+        if (tagI>=0) {
+            bam1_t *b;
+            b=bam_init1();
+            bam_read1_fromArray(RA->outBAMoneAlign[tagI], b);
+            uint8_t* auxp=bam_aux_get(b,"NM");
+            uint32_t auxv=bam_aux2i(auxp);
+            string tagSA1="SAZ"+RA->mapGen.chrName[b->core.tid]+','+to_string((uint)b->core.pos+1) +',' + ( (b->core.flag&0x10)==0 ? '+':'-') + \
+                    ',' + bam_cigarString(b) + ',' + to_string((uint)b->core.qual) + ',' + to_string((uint)auxv) + ';' ;
+
+            memcpy( (void*) (RA->outBAMoneAlign[ii]+RA->outBAMoneAlignNbytes[ii]), tagSA1.c_str(), tagSA1.size()+1);//copy string including \0 at the end
+            RA->outBAMoneAlignNbytes[ii]+=tagSA1.size()+1;
+             * ( (uint32*) RA->outBAMoneAlign[ii] ) = RA->outBAMoneAlignNbytes[ii]-sizeof(uint32);
+        };
+
+        if (P.outBAMunsorted) RA->outBAMunsorted->unsortedOneAlign(RA->outBAMoneAlign[ii], RA->outBAMoneAlignNbytes[ii], ii>0 ? 0 : bamBytesTotal);
+        if (P.outBAMcoord)    RA->outBAMcoord->coordOneAlign(RA->outBAMoneAlign[ii], RA->outBAMoneAlignNbytes[ii], (RA->iReadAll<<32) );
+    };
+
+};

--- a/source/ChimericDetection.h
+++ b/source/ChimericDetection.h
@@ -26,7 +26,7 @@ class ChimericDetection {
         int chimScoreBest;
 
         ChimericDetection(Parameters &Pin, Transcript ***trAll, uint *nWinTr, char** Read1in, Genome &genomeIn, fstream *ostreamChimJunctionIn, ReadAlign *RA);
-        bool chimericDetectionMult(uint nWin, uint *readLengthIn, int maxNonChimAlignScore, bool PEmerged_flag);
+        bool chimericDetectionMult(uint nWin, uint *readLengthIn, int maxNonChimAlignScore, ReadAlign *PEunmergedRA);
         fstream *ostreamChimJunction;
 };
 

--- a/source/ChimericDetection.h
+++ b/source/ChimericDetection.h
@@ -17,16 +17,12 @@ class ChimericDetection {
         uint nW, *nWinTr;
         char** Read1;
         Genome &outGen;
-        uint *readLength;
 
     public:
-        uint chimN;
         vector <ChimericAlign> chimAligns;
-        bool chimRecord;
-        int chimScoreBest;
 
         ChimericDetection(Parameters &Pin, Transcript ***trAll, uint *nWinTr, char** Read1in, Genome &genomeIn, fstream *ostreamChimJunctionIn, ReadAlign *RA);
-        bool chimericDetectionMult(uint nWin, uint *readLengthIn, int maxNonChimAlignScore, ReadAlign *PEunmergedRA);
+        bool chimericDetectionMult(uint nWin, uint *readLength, int maxNonChimAlignScore, ReadAlign *PEunmergedRA);
         fstream *ostreamChimJunction;
 };
 

--- a/source/ChimericDetection_chimericDetectionMult.cpp
+++ b/source/ChimericDetection_chimericDetectionMult.cpp
@@ -37,7 +37,7 @@ bool ChimericDetection::chimericDetectionMult(uint nW, uint *readLength, int max
     };
 
     chimAligns.clear();
-    chimScoreBest=0;
+    int chimScoreBest=0;
     std::size_t bestChimAlign=0; // points to element of chimAligns with highest chimScoreBest
 
     int maxPossibleAlignScore = (int)(readLength[0]+readLength[1]);
@@ -104,7 +104,7 @@ bool ChimericDetection::chimericDetectionMult(uint nW, uint *readLength, int max
     if (chimScoreBest==0)
         return false;
 
-    chimN=0;
+    uint chimN=0;
     for (auto cAit=chimAligns.begin(); cAit<chimAligns.end(); cAit++) {
         //scan all chimeras, find the number within score range
         if (cAit->chimScore >= minScoreToConsider)

--- a/source/Makefile
+++ b/source/Makefile
@@ -50,7 +50,7 @@ OBJECTS = SoloFeature_sumThreads.o SoloFeature_countVelocyto.o SoloFeature_count
 	ReadAlign_peOverlapMergeMap.o ReadAlign_mappedFilter.o \
 	ParametersChimeric_initialize.o ReadAlign_chimericDetection.o ReadAlign_chimericDetectionOld.o ReadAlign_chimericDetectionOldOutput.o\
 	ChimericDetection.o ChimericDetection_chimericDetectionMult.o ReadAlign_chimericDetectionPEmerged.o \
-	ChimericSegment.cpp ChimericAlign.cpp ChimericAlign_chimericJunctionOutput.o ChimericAlign_chimericStitching.o \
+	ChimericSegment.cpp ChimericAlign.cpp ChimericAlign_chimericJunctionOutput.o ChimericAlign_chimericBAMoutput.o ChimericAlign_chimericStitching.o \
 	stitchWindowAligns.o extendAlign.o stitchAlignToTranscript.o alignSmithWaterman.o \
 	Genome_genomeGenerate.o genomeParametersWrite.o genomeScanFastaFiles.o genomeSAindex.o \
 	Genome_insertSequences.o insertSeqSA.o funCompareUintAndSuffixes.o funCompareUintAndSuffixesMemcmp.o \

--- a/source/ParametersChimeric_initialize.cpp
+++ b/source/ParametersChimeric_initialize.cpp
@@ -80,10 +80,10 @@ void ParametersChimeric::initialize(Parameters *pPin)
             exitWithError(errOut.str(), std::cerr, pP->inOut->logMain, EXIT_CODE_PARAMETER, *pP);
     };
 
-    if (multimapNmax>0 && (out.bam || out.samOld)) {
+    if (multimapNmax>0 && out.samOld) {
             ostringstream errOut;
-            errOut <<"EXITING because of fatal PARAMETERS error: --chimMultimapNmax > 0 (new chimeric detection) presently only works with --chimOutType Junctions\n";
-            errOut <<"SOLUTION: re-run with --chimOutType Junctions\n";
+            errOut <<"EXITING because of fatal PARAMETERS error: --chimMultimapNmax > 0 (new chimeric detection) presently only works with --chimOutType Junctions/WithinBAM\n";
+            errOut <<"SOLUTION: re-run with --chimOutType Junctions/WithinBAM\n";
             exitWithError(errOut.str(), std::cerr, pP->inOut->logMain, EXIT_CODE_PARAMETER, *pP);
     };
 

--- a/source/ReadAlign.h
+++ b/source/ReadAlign.h
@@ -52,6 +52,7 @@ class ReadAlign {
         ReadAlign *peMergeRA; //ReadAlign for merged PE mates
 
         ChimericDetection *chimDet;
+        void peOverlapChimericSEtoPE(const Transcript *seTrIn1, const Transcript *seTrIn2, Transcript *peTrOut1, Transcript *peTrOut2);
 
         SoloRead *soloRead; //counts reads per CB per and outputs CB/UMI/gene into file, per thread
 

--- a/source/ReadAlign.h
+++ b/source/ReadAlign.h
@@ -55,6 +55,11 @@ class ReadAlign {
 
         SoloRead *soloRead; //counts reads per CB per and outputs CB/UMI/gene into file, per thread
 
+	//input,output
+        char** outBAMoneAlign;
+        uint* outBAMoneAlignNbytes;
+        int alignBAM(Transcript const &trOut, uint nTrOut, uint iTrOut, uint trChrStart, uint mateChr, uint mateStart, char mateStrand, int unmapType, bool *mateMapped, vector<int> outSAMattrOrder, char** outBAMarray, uint* outBAMarrayN);
+
     private:
         Parameters& P; //pointer to the parameters, will be initialized on construction
 
@@ -69,9 +74,6 @@ class ReadAlign {
         std::uniform_real_distribution<double> rngUniformReal0to1;//initialize in ReadAlign.cpp
 
         //input,output
-
-        char** outBAMoneAlign;
-        uint* outBAMoneAlignNbytes;
 
         ostringstream samStreamCIGAR, samStreamSJmotif, samStreamSJintron;
         vector <string> matesCIGAR;
@@ -168,7 +170,6 @@ class ReadAlign {
 
         bool outputTranscript(Transcript *trOut, uint nTrOut, ofstream *outBED);
         uint outputTranscriptSAM(Transcript const &trOut, uint nTrOut, uint iTrOut, uint mateChr, uint mateStart, char mateStrand, int unmapType, bool *mateMapped, ostream *outStream);
-        int alignBAM(Transcript const &trOut, uint nTrOut, uint iTrOut, uint trChrStart, uint mateChr, uint mateStart, char mateStrand, int unmapType, bool *mateMapped, vector<int> outSAMattrOrder, char** outBAMarray, uint* outBAMarrayN);
         void samAttrNM_MD (Transcript const &trOut, uint iEx1, uint iEx2, uint &tagNM, string &tagMD);
 
         void outputTranscriptSJ(Transcript const &trOut, uint nTrOut, OutSJ *outStream, uint sjReadStartN );

--- a/source/ReadAlignChunk.cpp
+++ b/source/ReadAlignChunk.cpp
@@ -94,6 +94,8 @@ ReadAlignChunk::ReadAlignChunk(Parameters& Pin, Genome &genomeIn, Transcriptome 
         delete RA->peMergeRA->chunkOutChimJunction;
         RA->peMergeRA->chunkOutChimJunction=RA->chunkOutChimJunction;//point to the same out-stream
         RA->peMergeRA->chimDet->ostreamChimJunction=RA->peMergeRA->chunkOutChimJunction;
+        RA->peMergeRA->outBAMunsorted=RA->outBAMunsorted;
+        RA->peMergeRA->outBAMcoord=RA->outBAMcoord;
     };
 };
 

--- a/source/ReadAlign_alignBAM.cpp
+++ b/source/ReadAlign_alignBAM.cpp
@@ -180,11 +180,8 @@ int ReadAlign::alignBAM(Transcript const &trOut, uint nTrOut, uint iTrOut, uint 
 
             if (readFilter=='Y') samFLAG|=0x200; //not passing quality control
 
-            if (alignType==-11 || alignType==-12 || alignType==-13) {
-                samFLAG|=0x800; //mark chimeric alignments
-            } else {//only non-chimeric alignments will be marked as non-primary, since chimeric are already marked with 0x800
-                if (!trOut.primaryFlag) samFLAG|=0x100;//mark not primary align
-            };
+            if (alignType==-11 || alignType==-12 || alignType==-13) samFLAG|=0x800; //mark chimeric alignments
+            if (!trOut.primaryFlag) samFLAG|=0x100; //mark not primary align
 
             iEx1 = (imate==0 ? 0 : iExMate+1);
             iEx2 = (imate==0 ? iExMate : trOut.nExons-1);

--- a/source/ReadAlign_chimericDetection.cpp
+++ b/source/ReadAlign_chimericDetection.cpp
@@ -46,7 +46,7 @@ void ReadAlign::chimericDetection() {
         chimRecord=chimericDetectionOld();
         chimericDetectionOldOutput();
     } else if (trBest->maxScore <= (int) (readLength[0]+readLength[1]) - (int) P.pCh.nonchimScoreDropMin) {//require big enough drop in the best score
-        chimRecord=chimDet->chimericDetectionMult(nW, readLength, trBest->maxScore, false);
+        chimRecord=chimDet->chimericDetectionMult(nW, readLength, trBest->maxScore, NULL);
     };
 
     if ( chimRecord ) {

--- a/source/ReadAlign_chimericDetectionOldOutput.cpp
+++ b/source/ReadAlign_chimericDetectionOldOutput.cpp
@@ -1,5 +1,6 @@
 #include "ReadAlign.h"
 #include "BAMfunctions.h"
+#include "ChimericAlign.h"
 
 void ReadAlign::chimericDetectionOldOutput() {
 
@@ -7,110 +8,31 @@ void ReadAlign::chimericDetectionOldOutput() {
         return;
     };
 
-    chimN=2; //this  is hard-coded for now
     //re-calculate the score for chimeric transcripts
     trChim[0].alignScore(Read1, mapGen.G, P);
     trChim[1].alignScore(Read1, mapGen.G, P);
 
-    int chimRepresent=-999, chimType=0;
-    if (trChim[0].exons[0][EX_iFrag]!=trChim[0].exons[trChim[0].nExons-1][EX_iFrag]) {//tr0 has both mates
-        chimRepresent = 0;
-        chimType = 1;
-        trChim[0].primaryFlag=true;//paired portion is primary
-        trChim[1].primaryFlag=false;
-    } else if (trChim[1].exons[0][EX_iFrag]!=trChim[1].exons[trChim[1].nExons-1][EX_iFrag]) {//tr1 has both mates
-        chimRepresent = 1;
-        chimType = 1;
-        trChim[1].primaryFlag=true;//paired portion is primary
-        trChim[0].primaryFlag=false;
-    } else if (trChim[0].exons[0][EX_iFrag]!=trChim[1].exons[0][EX_iFrag]) {//tr0 and tr1 are single different mates
-        chimRepresent = -1;
-        chimType = 2;
-        trChim[0].primaryFlag=true;
-        trChim[1].primaryFlag=true;
-    } else  {//two chimeric segments are on the same mate - this can only happen for single-end reads
-        chimRepresent = (trChim[0].maxScore > trChim[1].maxScore) ? 0 : 1;
-        chimType = 3;
-        trChim[chimRepresent].primaryFlag=true;
-        trChim[1-chimRepresent].primaryFlag=false;
-    };
-
-    if (P.pCh.out.bam) {//BAM output
-        int alignType, bamN=0, bamIsuppl=-1, bamIrepr=-1;
-        uint bamBytesTotal=0;//estimate of the total size of all bam records, for output buffering
-        uint mateChr,mateStart;
-        uint8_t mateStrand;
-        for (uint itr=0;itr<chimN;itr++) {//generate bam for all chimeric pieces
-            if (chimType==2) {//PE, encompassing
-                mateChr=trChim[1-itr].Chr;
-                mateStart=trChim[1-itr].exons[0][EX_G];
-                mateStrand=(uint8_t) (trChim[1-itr].Str!=trChim[1-itr].exons[0][EX_iFrag]);
-                alignType=-10;
-            } else {//spanning chimeric alignment, could be PE or SE
-                mateChr=-1;mateStart=-1;mateStrand=0;//no need fot mate info unless this is the supplementary alignment
-                if (chimRepresent==(int)itr) {
-                    alignType=-10; //this is representative part of chimeric alignment, record is as normal; if encompassing chimeric junction, both are recorded as normal
-                    bamIrepr=bamN;
-                    if (trChim[itr].exons[0][EX_iFrag]!=trChim[1-itr].exons[0][EX_iFrag]) {//the next mate is chimerically split
-                        ++bamIrepr;
-                    };
-//                     if (chimType==3) {
-//                         bamIrepr=bamN;
-//                     } else if (trChim[itr].exons[0][EX_iFrag]==trChim[1-itr].exons[0][EX_iFrag]) {
-//
-//                    };
-//                     bamIrepr=( (itr%2)==(trChim[itr].Str) && chimType!=3) ? bamN+1 : bamN;//this is the mate that is chimerically split
-                } else {//"supplementary" chimeric segment
-                    alignType=P.pCh.out.bamHardClip ? ( ( itr%2==trChim[itr].Str ) ? -12 : -11) : -13 ; //right:left chimeric junction
-                    bamIsuppl=bamN;
-                    if (chimType==1) {//PE alignment, need mate info for the suppl
-                        uint iex=0;
-                        for (;iex<trChim[chimRepresent].nExons-1;iex++) {
-                            if (trChim[chimRepresent].exons[iex][EX_iFrag]!=trChim[itr].exons[0][EX_iFrag]) {
-                                break;
-                            };
-                        };
-                        mateChr=trChim[chimRepresent].Chr;
-                        mateStart=trChim[chimRepresent].exons[iex][EX_G];
-                        mateStrand=(uint8_t) (trChim[chimRepresent].Str!=trChim[chimRepresent].exons[iex][EX_iFrag]);
-                    };
-                };
-
-            };
-
-            bamN+=alignBAM(trChim[itr], 1, 0, mapGen.chrStart[trChim[itr].Chr],  mateChr, mateStart-mapGen.chrStart[(mateChr<mapGen.nChrReal ? mateChr : 0)], mateStrand, \
-                            alignType, NULL, P.outSAMattrOrder, outBAMoneAlign+bamN, outBAMoneAlignNbytes+bamN);
-            bamBytesTotal+=outBAMoneAlignNbytes[0]+outBAMoneAlignNbytes[1];//outBAMoneAlignNbytes[1] = 0 if SE is recorded
-        };
-
-        //write all bam lines
-        for (int ii=0; ii<bamN; ii++) {//output all pieces
-            int tagI=-1;
-            if (ii==bamIrepr) {
-              tagI=bamIsuppl;
-            } else if (ii==bamIsuppl) {
-              tagI=bamIrepr;
-            };
-            if (tagI>=0) {
-                bam1_t *b;
-                b=bam_init1();
-                bam_read1_fromArray(outBAMoneAlign[tagI], b);
-                uint8_t* auxp=bam_aux_get(b,"NM");
-                uint32_t auxv=bam_aux2i(auxp);
-                string tagSA1="SAZ"+mapGen.chrName[b->core.tid]+','+to_string((uint)b->core.pos+1) +',' + ( (b->core.flag&0x10)==0 ? '+':'-') + \
-                        ',' + bam_cigarString(b) + ',' + to_string((uint)b->core.qual) + ',' + to_string((uint)auxv) + ';' ;
-
-                 memcpy( (void*) (outBAMoneAlign[ii]+outBAMoneAlignNbytes[ii]), tagSA1.c_str(), tagSA1.size()+1);//copy string including \0 at the end
-                 outBAMoneAlignNbytes[ii]+=tagSA1.size()+1;
-                 * ( (uint32*) outBAMoneAlign[ii] ) = outBAMoneAlignNbytes[ii]-sizeof(uint32);
-            };
-
-            if (P.outBAMunsorted) outBAMunsorted->unsortedOneAlign(outBAMoneAlign[ii], outBAMoneAlignNbytes[ii], ii>0 ? 0 : bamBytesTotal);
-            if (P.outBAMcoord)    outBAMcoord->coordOneAlign(outBAMoneAlign[ii], outBAMoneAlignNbytes[ii], (iReadAll<<32) );
-        };
-    };
+    if (P.pCh.out.bam) //BAM output
+        ChimericAlign::chimericBAMoutput(&trChim[0], &trChim[1], this, 0, 1, true, P);
 
     if (P.pCh.out.samOld) {
+
+        chimN=2; //this  is hard-coded for now
+        if (trChim[0].exons[0][EX_iFrag]!=trChim[0].exons[trChim[0].nExons-1][EX_iFrag]) {//tr0 has both mates
+            trChim[0].primaryFlag=true;//paired portion is primary
+            trChim[1].primaryFlag=false;
+        } else if (trChim[1].exons[0][EX_iFrag]!=trChim[1].exons[trChim[1].nExons-1][EX_iFrag]) {//tr1 has both mates
+            trChim[1].primaryFlag=true;//paired portion is primary
+            trChim[0].primaryFlag=false;
+        } else if (trChim[0].exons[0][EX_iFrag]!=trChim[1].exons[0][EX_iFrag]) {//tr0 and tr1 are single different mates
+            trChim[0].primaryFlag=true;
+            trChim[1].primaryFlag=true;
+        } else  {//two chimeric segments are on the same mate - this can only happen for single-end reads
+            int chimRepresent = (trChim[0].maxScore > trChim[1].maxScore) ? 0 : 1;
+            trChim[chimRepresent].primaryFlag=true;
+            trChim[1-chimRepresent].primaryFlag=false;
+        };
+
         for (uint iTr=0;iTr<chimN;iTr++)
         {//write all chimeric pieces to Chimeric.out.sam/junction
             if (P.readNmates==2) {//PE: need mate info

--- a/source/ReadAlign_chimericDetectionPEmerged.cpp
+++ b/source/ReadAlign_chimericDetectionPEmerged.cpp
@@ -1,6 +1,7 @@
 #include "ReadAlign.h"
 #include "BAMfunctions.h"
 
+
 void ReadAlign::chimericDetectionPEmerged(ReadAlign &seRA) {
 
     chimRecord=false;
@@ -20,59 +21,14 @@ void ReadAlign::chimericDetectionPEmerged(ReadAlign &seRA) {
             return;
         };
 
-        //convert merged into PE
-        for (uint ii=0; ii<2; ii++) {
-            trChim[ii]=*trInit;
-            trChim[ii].peOverlapSEtoPE(peOv.mateStart,seRA.trChim[ii]);
-        };
-
-        uint segLen[2][2]; //segment length [trChim][mate]
-        uint segEx[2];//last exon of the mate0 [trChim]
-        uint segLmin=-1LLU, i1=0,i2=0;
-        for (uint ii=0; ii<2; ii++) {
-            segLen[ii][0]=0;
-            segLen[ii][1]=0;
-            for (uint iex=0; iex<trChim[ii].nExons; iex++) {
-                if (trChim[ii].exons[iex][EX_iFrag]==trChim[ii].exons[0][EX_iFrag]) {
-                    segLen[ii][0]+=trChim[ii].exons[iex][EX_L];
-                    segEx[ii]=iex;
-                } else {
-                    segLen[ii][1]+=trChim[ii].exons[iex][EX_L];
-                };
-            };
-            for (uint jj=0; jj<2; jj++) {
-                if (segLen[ii][jj]<segLmin || (segLen[ii][jj]==segLmin && trChim[ii].exons[0][EX_G]>trChim[ii-1].exons[0][EX_G])) {
-                    segLmin=segLen[ii][jj];
-                    i1=ii;//trChim of the shortest segment length
-                    i2=jj;//mate of the shortest segment length
-                };
-            };
-        };
-
-        if (i2==1) {//eliminate mate1: simply cut the exons that belong to mate1
-            trChim[i1].nExons=segEx[i1]+1;
-        } else {//eliminate mate 0: shift mate1 exon to the beginning
-            for (uint iex=0; iex<trChim[i1].nExons; iex++) {
-                uint iex1=iex+segEx[i1]+1;
-                for (uint ii=0; ii<EX_SIZE; ii++) {
-                    trChim[i1].exons[iex][ii]=trChim[i1].exons[iex1][ii];
-                };
-                trChim[i1].canonSJ[iex]=trChim[i1].canonSJ[iex1];
-                trChim[i1].sjAnnot[iex]=trChim[i1].sjAnnot[iex1];
-                trChim[i1].sjStr[iex]=trChim[i1].sjStr[iex1];
-                trChim[i1].shiftSJ[iex][0]=trChim[i1].shiftSJ[iex1][0];
-                trChim[i1].shiftSJ[iex][1]=trChim[i1].shiftSJ[iex1][1];
-            };
-            trChim[i1].nExons=trChim[i1].nExons-segEx[i1]-1;
-        };
-
+        peOverlapChimericSEtoPE(&seRA.trChim[0], &seRA.trChim[1], &trChim[0], &trChim[1]);
         chimericDetectionOldOutput();
 
     } else if (trBest->maxScore <= (int) (readLength[0]+readLength[1]) - (int) P.pCh.nonchimScoreDropMin) {//require big enough drop in the best score
 
         // new chimeric detection routine
 
-        chimRecord=seRA.chimDet->chimericDetectionMult(seRA.nW, seRA.readLength, seRA.trBest->maxScore, true);
+        chimRecord=seRA.chimDet->chimericDetectionMult(seRA.nW, seRA.readLength, seRA.trBest->maxScore, this);
     };
 
     if ( chimRecord ) {

--- a/source/ReadAlign_peOverlapMergeMap.cpp
+++ b/source/ReadAlign_peOverlapMergeMap.cpp
@@ -141,7 +141,7 @@ void ReadAlign::peMergeMates() {
     return;
 };
 
-void Transcript::peOverlapSEtoPE(uint* mateStart, Transcript &t) {//convert alignment from merged-SE to PE
+void Transcript::peOverlapSEtoPE(uint* mateStart, const Transcript &t) {//convert alignment from merged-SE to PE
 
     uint mLen[2];
     mLen[0]=readLength[t.Str];
@@ -293,3 +293,58 @@ void ReadAlign::peOverlapSEtoPE(ReadAlign &seRA) {//ReAdAlign: convert SE to PE 
 
     return;
 };
+
+void ReadAlign::peOverlapChimericSEtoPE(const Transcript *seTrIn1, const Transcript *seTrIn2, Transcript *peTrOut1, Transcript *peTrOut2) {
+
+    //convert merged into PE
+    Transcript tempTrChim[2];
+    tempTrChim[0]=*trInit;
+    tempTrChim[1]=*trInit;
+    tempTrChim[0].peOverlapSEtoPE(peOv.mateStart,*seTrIn1);
+    tempTrChim[1].peOverlapSEtoPE(peOv.mateStart,*seTrIn2);
+
+    uint segLen[2][2]; //segment length [tempTrChim][mate]
+    uint segEx[2];//last exon of the mate0 [tempTrChim]
+    uint segLmin=-1LLU, i1=0,i2=0;
+    for (uint ii=0; ii<2; ii++) {
+        segLen[ii][0]=0;
+        segLen[ii][1]=0;
+        for (uint iex=0; iex<tempTrChim[ii].nExons; iex++) {
+            if (tempTrChim[ii].exons[iex][EX_iFrag]==tempTrChim[ii].exons[0][EX_iFrag]) {
+                segLen[ii][0]+=tempTrChim[ii].exons[iex][EX_L];
+                segEx[ii]=iex;
+            } else {
+                segLen[ii][1]+=tempTrChim[ii].exons[iex][EX_L];
+            };
+        };
+        for (uint jj=0; jj<2; jj++) {
+            if (segLen[ii][jj]<segLmin || (segLen[ii][jj]==segLmin && tempTrChim[ii].exons[0][EX_G]>tempTrChim[ii-1].exons[0][EX_G])) {
+                segLmin=segLen[ii][jj];
+                i1=ii;//tempTrChim of the shortest segment length
+                i2=jj;//mate of the shortest segment length
+            };
+        };
+    };
+
+    if (i2==1) {//eliminate mate1: simply cut the exons that belong to mate1
+        tempTrChim[i1].nExons=segEx[i1]+1;
+    } else {//eliminate mate 0: shift mate1 exon to the beginning
+        for (uint iex=0; iex<tempTrChim[i1].nExons; iex++) {
+            uint iex1=iex+segEx[i1]+1;
+            for (uint ii=0; ii<EX_SIZE; ii++) {
+                tempTrChim[i1].exons[iex][ii]=tempTrChim[i1].exons[iex1][ii];
+            };
+            tempTrChim[i1].canonSJ[iex]=tempTrChim[i1].canonSJ[iex1];
+            tempTrChim[i1].sjAnnot[iex]=tempTrChim[i1].sjAnnot[iex1];
+            tempTrChim[i1].sjStr[iex]=tempTrChim[i1].sjStr[iex1];
+            tempTrChim[i1].shiftSJ[iex][0]=tempTrChim[i1].shiftSJ[iex1][0];
+            tempTrChim[i1].shiftSJ[iex][1]=tempTrChim[i1].shiftSJ[iex1][1];
+        };
+        tempTrChim[i1].nExons=tempTrChim[i1].nExons-segEx[i1]-1;
+    };
+
+    *peTrOut1=tempTrChim[0];
+    *peTrOut2=tempTrChim[1];
+    return;
+};
+

--- a/source/Transcript.h
+++ b/source/Transcript.h
@@ -66,7 +66,7 @@ public:
     intScore alignScore(char **Read1, char *G, Parameters &P);
     int variationAdjust(const Genome &mapGen, char *R);
     string generateCigarP(); //generates CIGAR
-    void peOverlapSEtoPE(uint* mSta, Transcript &t);
+    void peOverlapSEtoPE(uint* mSta, const Transcript &t);
     void extractSpliceJunctions(vector<array<uint64,2>> &sjOut, bool &annotYes);
 
 private:


### PR DESCRIPTION
Hi Alex,

This is a pull request which enables STAR to report multimapping chimeric reads in BAM format as discussed in issue #462.

The [SAM format specification](https://samtools.github.io/hts-specs/SAMv1.pdf) and [SAM tags specification](http://samtools.github.io/hts-specs/SAMtags.pdf) are not explicit on how to represent multimapping chimeric alignments. BWA reports them as secondary alignments without supplementary flag/tag. However, this has the major disadvantage that the supplementary nature of these alignments is not evident from the alignment record. Fusion detection tools that build on STAR would thus have a hard time extracting the relevant alignments. I contemplated what would be the best way and came up with the following:

* All supplementary chimeric alignments should be flagged as supplementary (`0x800` flag set). *Exactly one* of the supplementary chimeric alignments should be flagged primary (`0x100` flag unset); *all others* should be flagged as secondary (`0x100` flag set) *in addition to the supplementary flag*. This is in line with [the initial discussion about introducing the supplementary flag](https://sourceforge.net/p/samtools/mailman/search/?q=%22Proposing+a+new+bit+flag+0x800%22&limit=250&sort=posted_date+asc&page=0), specifically with [this mail](https://sourceforge.net/p/samtools/mailman/message/30852553/) and [this mail](https://sourceforge.net/p/samtools/mailman/message/30852329/).

* The supplementary alignment with the highest alignment score is marked primary. In case of ties, the marking is arbitrary. This is recommended by the SAM format specification for normal (non-chimeric) reads and it makes sense to apply the same logic to chimeric reads.

* The SAM format specification says it is arbitrary which segment should be considered the representative (a.k.a. anchor alignment) and which the supplementary. Therefore, we can stick to what STAR has done with uniquely mapping in the past, i.e., consider the mates mapping in close proximity as the representative and the (usually) short chimeric segment as the supplementary.

* The SAM tags specfication requires that supplementary alignments point to their related representative alignment using the `SA` tag. Likewise, the representative alignment must point to the supplementary using the `SA` tag. This becomes an issue, when only the supplementary maps to multiple loci, while the representative maps to a single locus. Since the SAM format specification allows each tag to appear at most once, the representative would have to opt for one of the multimapping supplementaries. This issue can be resolved by also duplicating the representatives, such that each supplementary has exactly one related representative and vice versa. At first glance, this may seem as if this would generate a lot of redundant SAM records. But it makes the most sense to me for several reasons: (1) The case that the representative maps uniquely and the supplementary maps mutiple times really is a special case of the more general case that both map multiple times. Admittedly, it is a frequent case, but it is nevertheless a special case. It does not make sense to treat it differently than the generalized situation, because this would require quite a bit of additional code in STAR to remove the redundant SAM records, and tools that build on STAR would have to disentangle it again. (2) Multimapping *non-chimeric* paired-end reads are already treated by STAR like this: even when only one of them maps to multiple loci, the other one is duplicated, too. Doing the same for multimapping chimeric reads would only be consistent. (3) As stated above, it is the only way to fill the `SA` tags with consistent values.

* All chimeric alignments with the same `QNAME` should have a `MAPQ` < 255 and the same value for the `NH` tag, even if only the supplementary segment maps multiple times. This makes sense for the same reasons given in the previous point.

* Analogous to the multimapping supplementaries, exactly one of the representatives should be primary (`0x100` flag unset), while all others should be flagged secondary (`0x100` flag set). Related supplementaries and representatives should have identical `HI` tags. Thus, multimapping chimeric reads are represented exactly like uniquely mapping chimeric reads when they are segregated by their `HI` tags, which makes it very easy to adapt existing fusion detection methods to STAR's new ability. In the simplest case, a user could just remove all alignments marked as secondary and use an existing fusion detection algorithm without any modification.                                                                               
                                                                                                                                                                                    
In accordance with these conclusions, I adapted the code of STAR:                                                                                                                   

* I moved the BAM-related code from `ReadAlign::chimericDetectionOldOutput()` to a new function `ChimericAlign::chimericBAMoutput()`, because you said that the `ChimericAlign` class should host the chimeric detection code in the future. I named the function analogously to the existing `ChimericAlign::chimericJunctionOutput()` function. The alternative would have been to have a lot of redundant code in the `ReadAlign` and `ChimericAlign` classes.

* `ReadAlign::chimericDetectionOldOutput()` now simply makes a call to the new function and does not contain any BAM-related code anymore.

* Since the `ChimericAlign` class is a separate class from the `ReadAlign` class, I had to make some members/methods of `ReadAlign` public that were previously private: `outBAMoneAlign`, `outBAMoneAlignNbytes`, `alignBAM()`. I hope this does not conflict with abstract concepts of the `ReadAlign` class. Alternatively, we could write getters and setters to do the same, but I don't really see a point in doing do.

* Similarly, I had to make the `RA` member of the `ChimericAlign` class public, because it is passed as an argument to the new `ChimericAlign::chimericBAMoutput()` function. This can be undone, once the old chimeric detection code has been removed, because `RA` only needs to be passed as an argument for the call from `ReadAlign::chimericDetectionOldOutput()`. The `ChimericAlign` class could access it directly due to it being a member of the class.

* Once the old chimeric detection code has been removed, the parameters `al1`, `al2`, `RA`, and `P` can also be removed from the new function `ChimericAlign::chimericBAMoutput()`, because they are only needed for the call from `ReadAlign::chimericDetectionOldOutput()`. I deliberately named them exactly like the members of the `ChimericAlign` class, because they are in fact the same, and cleaning up the code after the old chimeric detection code has been removed will then be as easy as wiping the parameters.

* The new function `ChimericAlign::chimericBAMoutput()` is currently declared `static`. This declaration can also be removed when the old chimeric detection code has been deleted.

I tested the new code on a few samples and also made sure that STAR still generates the same output when the old code is used (i.e., `--chimMultimapNmax 0`).

Looking forward to your feedback,
Sebastian
