### PR TITLE
Fix `readFilesPrefix` docs preifx mispell

### DIFF
--- a/extras/doc-latex/parametersDefault.tex
+++ b/extras/doc-latex/parametersDefault.tex
@@ -143,7 +143,7 @@
   \optLine{string(s): paths to files that contain input read1 (and, if needed,  read2)} 
 \optName{readFilesPrefix}
   \optValue{-}
-  \optLine{string: preifx for the read files names, i.e. it will be added in front of the strings in --readFilesIn} 
+  \optLine{string: prefix for the read files names, i.e. it will be added in front of the strings in --readFilesIn} 
   \optLine{-: no prefix} 
 \optName{readFilesCommand}
   \optValue{-}

--- a/source/parametersDefault
+++ b/source/parametersDefault
@@ -126,7 +126,7 @@ readFilesIn                 Read1 Read2
     string(s): paths to files that contain input read1 (and, if needed,  read2)
 
 readFilesPrefix             -
-    string: preifx for the read files names, i.e. it will be added in front of the strings in --readFilesIn
+    string: prefix for the read files names, i.e. it will be added in front of the strings in --readFilesIn
                             -: no prefix
 
 readFilesCommand             -


### PR DESCRIPTION
Super minor typo I noticed when I was going through the doc for the `readFilesPrefix` parameter. 