### PR TITLE
Declare log2+floor by including math.h

### DIFF
--- a/source/Genome_genomeLoad.cpp
+++ b/source/Genome_genomeLoad.cpp
@@ -1,3 +1,4 @@
+#include <math.h>
 #include "Genome.h"
 #include "SuffixArrayFuns.h"
 #include "PackedArray.h"


### PR DESCRIPTION
This is the error I otherwise get:
```
g++ -c -Wdate-time -D_FORTIFY_SOURCE=2  -O3 -std=c++11 -fopenmp -D'COMPILATION_TIME_PLACE="<not set in Debian>"' -flto -flto -g -O2 -fdebug-prefix-map=/home/moeller/git/med-team/rna-star=. -fstack-protector-strong -Wformat -Werror=format-security -Wdate-time -D_FORTIFY_SOURCE=2 -std=c++0x -g -O2 -fdebug-prefix-map=/home/moeller/git/med-team/rna-star=. -fstack-protector-strong -Wformat -Werror=format-security -D'COMPILATION_TIME_PLACE="<not set in Debian>"' Genome_genomeOutLoad.cpp
Genome_genomeLoad.cpp: In member function ‘void Genome::genomeLoad()’:
Genome_genomeLoad.cpp:152:35: error: ‘log’ was not declared in this scope; did you mean ‘long’?
  152 |         GstrandBit = (uint) floor(log(nGenome)/log(2))+1;
      |                                   ^~~
      |                                   long
Genome_genomeLoad.cpp:152:29: error: ‘floor’ was not declared in this scope
  152 |         GstrandBit = (uint) floor(log(nGenome)/log(2))+1;
      |                             ^~~~~
Genome_genomeLoad.cpp:434:39: error: ‘log2’ was not declared in this scope
  434 |         P.winBinNbits = (uint) floor( log2( max( max(4LLU,P.alignIntronMax), (P.alignMatesGapMax==0 ? 1000LLU : P.alignMatesGapMax) ) /4 ) + 0.5);
      |                                       ^~~~
Genome_genomeLoad.cpp:434:32: error: ‘floor’ was not declared in this scope
  434 |         P.winBinNbits = (uint) floor( log2( max( max(4LLU,P.alignIntronMax), (P.alignMatesGapMax==0 ? 1000LLU : P.alignMatesGapMax) ) /4 ) + 0.5);
      |                                ^~~~~
make[2]: *** [Makefile:78: Genome_genomeLoad.o] Error 1
make[2]: *** Waiting for unfinished jobs....
make[2]: Leaving directory '/home/moeller/git/med-team/rna-star/source'
```
I just saw that I messed up the description of my commit. Please kindly fix this for me, I mean, just add the line and ignore this PR :o) 
Thanks!
Steffen