### PR TITLE
Also cleaning opal/opal.o

### DIFF
--- a/source/Makefile
+++ b/source/Makefile
@@ -88,7 +88,7 @@ opal/opal.o : opal/opal.cpp opal/opal.h
 
 .PHONY: clean
 clean:
-	rm -f *.o STAR STARstatic STARlong Depend.list
+	rm -f *.o opal/opal.o STAR STARstatic STARlong Depend.list
 
 .PHONY: clean_solo
 clean_solo:


### PR DESCRIPTION
My first reflex was to have $(OBJECTS) removed, but OBJECTS also has many .cpp files. If those are not autogenerated, maybe have a separate variable for them?
Thanks!
Steffen