### PR TITLE
Show which STAR binary+version is executed

### DIFF
--- a/source/STAR.cpp
+++ b/source/STAR.cpp
@@ -65,7 +65,7 @@ int main(int argInN, char* argIn[]) {
     Parameters P; //all parameters
     P.inputParameters(argInN, argIn);
 
-    *(P.inOut->logStdOut) << timeMonthDayTime(g_statsAll.timeStart) << " ..... started STAR run\n" <<flush;
+    *(P.inOut->logStdOut) << timeMonthDayTime(g_statsAll.timeStart) << " ..... started STAR run (" << argIn[0] << ")\n" <<flush;
 
     //runMode
     if ( P.runMode == "alignReads" || P.runMode == "soloCellFiltering" ){


### PR DESCRIPTION
This is not really a PR since this needs to be adapted to your style and you may be aware of tools parsing that line. It is more an expression of despair on my side. STAR for me is wrapped by pigx-rnaseq. I got a bit into trouble with my local installation and now thought I should better have a look at the official guix-provided installation and am not fully confident that the STAR binary executed is the one I installed or the one that guix installed. The log file looks like
```
sh: warning: setlocale: LC_ALL: cannot change locale (en_US.UTF-8)
/gnu/store/mmhimfwmmidf09jw1plw3aw1g1zn2nkh-bash-static-5.0.16/bin/sh: warning: setlocale: LC_ALL: cannot change locale (en_US.UTF-8)
Feb 23 21:54:52 ..... started STAR run
Feb 23 21:54:57 ..... loading genome

EXITING: FATAL INPUT ERROR: unrecognized parameter name "genomeType" in input "genomeParameters.txt"
SOLUTION: use correct parameter name (check the manual)

Feb 23 21:54:57 ...... FATAL ERROR, exiting
/gnu/store/pwcp239kjf7lnj5i4lkdzcfcxwcfyk72-bash-minimal-5.0.16/bin/bash: warning: setlocale: LC_ALL: cannot change locale (en_US.UTF-8)
```
and if the path of the binary executed would surface here then this would help - also the version would be nice to see. I did not see this genomeType error before - but that is about something else :o/

**Update:**
```
$ find /gnu/ -name STAR
/gnu/store/zd7gdv173x41rmjdgc7qr3ycasna28hd-star-2.7.3a/bin/STAR
/gnu/store/7bjj53q9lx87aw4ljs9b6wrs7qs4666v-star-2.7.3a/bin/STAR
```
just a hunch. But with that extra information in the logs, I would know for sure and could report with better confidence to the authors of pigx-rnaseq. Many thanks!   Steffen