### PR TITLE
Fix minor error (copy & paste)

### DIFF
--- a/extras/doc-latex/parametersDefault.tex
+++ b/extras/doc-latex/parametersDefault.tex
@@ -272,7 +272,7 @@
   \optOpt{Log}   \optOptLine{log messages}
   \optOpt{SAM}   \optOptLine{alignments in SAM format (which normally are output to Aligned.out.sam file), normal standard output will go into Log.std.out}
   \optOpt{BAM{\textunderscore}Unsorted}   \optOptLine{alignments in BAM format, unsorted. Requires --outSAMtype BAM Unsorted}
-  \optOpt{BAM{\textunderscore}SortedByCoordinate}   \optOptLine{alignments in BAM format, unsorted. Requires --outSAMtype BAM SortedByCoordinate}
+  \optOpt{BAM{\textunderscore}SortedByCoordinate}   \optOptLine{alignments in BAM format, sorted by coordinate. Requires --outSAMtype BAM SortedByCoordinate}
   \optOpt{BAM{\textunderscore}Quant}   \optOptLine{alignments to transcriptome in BAM format, unsorted. Requires --quantMode TranscriptomeSAM}
 \end{optOptTable}
 \optName{outReadsUnmapped}


### PR DESCRIPTION
# documentation improvement
Just a minor error in the manual (probably from a copy & paste) for: 15.12 Output: general

BAM SortedByCoordinate
alignments in BAM format, **unsorted**.

should say:

BAM SortedByCoordinate
alignments in BAM format, **sorted by coordinate**.