### PR TITLE
assign supplementary alignment to correct mate when mates fully overlap

### DIFF
--- a/source/ReadAlign_peOverlapMergeMap.cpp
+++ b/source/ReadAlign_peOverlapMergeMap.cpp
@@ -316,7 +316,8 @@ void ReadAlign::peOverlapChimericSEtoPE(const Transcript *seTrIn1, const Transcr
 
     uint segLen[2][2]; //segment length [tempTrChim][mate]
     uint segEx[2];//last exon of the mate0 [tempTrChim]
-    uint segLmin=-1LLU, i1=0,i2=0;
+    uint i1=0,i2=0; //indices of mate to eliminate i1=[tempTrChim], i2=[mate]
+    uint posOfJunctionInRead=0; //position of chimeric junction in read
     for (uint ii=0; ii<2; ii++) {
         segLen[ii][0]=0;
         segLen[ii][1]=0;
@@ -328,9 +329,15 @@ void ReadAlign::peOverlapChimericSEtoPE(const Transcript *seTrIn1, const Transcr
                 segLen[ii][1]+=tempTrChim[ii].exons[iex][EX_L];
             };
         };
+
+        //find mate with shortest mapped segment
+        //in case of tie, use longest mate as tie-breaker (where posOfJunctionInRead is highest)
+        uint readLen0=readLengthOriginal[tempTrChim[ii].exons[0][EX_iFrag]];
+        uint readLen1=readLengthOriginal[1-tempTrChim[ii].exons[0][EX_iFrag]];
         for (uint jj=0; jj<2; jj++) {
-            if (segLen[ii][jj]<segLmin || (segLen[ii][jj]==segLmin && tempTrChim[ii].exons[0][EX_G]>tempTrChim[ii-1].exons[0][EX_G])) {
-                segLmin=segLen[ii][jj];
+            uint curPosOfJunctionInRead = tempTrChim[ii].exons[jj][EX_R]>readLen0 ? readLen0+readLen1+1-tempTrChim[ii].exons[jj][EX_R] : tempTrChim[ii].exons[jj][EX_R];
+            if (segLen[ii][jj]<segLen[i1][i2] || (segLen[ii][jj]==segLen[i1][i2] && curPosOfJunctionInRead>posOfJunctionInRead)) {
+                posOfJunctionInRead=curPosOfJunctionInRead;
                 i1=ii;//tempTrChim of the shortest segment length
                 i2=jj;//mate of the shortest segment length
             };


### PR DESCRIPTION
Hi Alex,

This pull request fixes #1135. The non-deterministic behavior/bug was caused by the following line:

https://github.com/alexdobin/STAR/blob/ffb66fb04e2642d1c2df87a31344552487ec491d/source/ReadAlign_peOverlapMergeMap.cpp#L332

Specifically, when the variable `ii` was `0`, the term `tempTrChim[ii-1]` accessed a negative index, which is invalid. I am surprised this did not produce segfaults. Somehow, it simply returned 0 in my tests, which leads to more or less random behavior, because the supplementary is assigned to mate1 or mate2 based on a meaningless criterion.

However, accessing a non-existent array index was not the only issue. The original code in the above line used the genomic mapping coordinate as a tie-breaker when there were two equally valid options for defining the representative and the supplementary. This is not meaningful, because effectively, this also means that the supplementary is assigned randomly to mate1 or mate2 based on an irrelevant criterion. So fixing the negative index access did not fix the actual problem. I implemented a more meaningful tie-breaker: The longer alignment is chosen as the representative, which is identified as having the chimeric junction more towards the end of the read. This leads to correct assignment of the supplementary to the representative in ambiguous situations.

This pull request correctly fixes all the examples given in issue #1135. I have further tested in on 133 samples with `--chimMultimapNmax` and `--peOverlapNbasesMin` both > 0, where the fix is supposed to have an effect. STAR processed them without error and I could confirm by random inspection of differences between patched and unpatched STAR that the new alignments were correct. For a full integration test, I ran my fusion detection tool on the new BAMs and did not observe problems. I also tested it on a sample with one or both of the parameters `--chimMultimapNmax` and `--peOverlapNbasesMin` set to 0, where the modified section of code should not be involved. The alignments were identical to the unpatched STAR version in those runs as expected.

Important note: Before implementing this fix, I expected the issue to completely vanish with the fix. However, it turns out it can still happen that the supplementary is assigned to the wrong mate - but only in cases where there is no other option than incorrect assignment, namely, when the insert size is smaller than the read length, such that adapters are incorporated into the reads. This behavior is not fixable (other than not reporting chimeric alignments for such reads). But it's not problematic either IMO, because these chimeric alignments are uninteresting anyway. This pull request fixes only the issue where the insert size is *precisely* the read length, such that the mates fully overlap. You should keep this in mind when selecting suitable reads for your own tests. I made a schematic for clarity:

![SA_assignment](https://user-images.githubusercontent.com/10560654/146090592-c0602d59-b774-4d45-ba24-85edc9a2322a.png)

The bug only triggers in the rare case that mates fully overlap. For normal libraries, it affects less than 1% of the chimeric alignments. Still, I do think that the fix is useful, because this rare case is not so rare in libraries with small insert size. Such libraries were heavily affected by the bug, because here, many mates overlap fully. I would be grateful if this patch made it into the next release. I have been delaying several pipeline developments in aspiration of a fix and would be happy to finalize them at last. Then again, I know you get tons of requests all the time, so I can understand if this does not fit into your planned schedule for the next release.

Regards,
Sebastian
