### PR TITLE
Add missing `#include <array>` (GCC 12)

### DIFF
--- a/source/SoloCommon.h
+++ b/source/SoloCommon.h
@@ -1,6 +1,7 @@
 #ifndef H_SoloCommon
 #define H_SoloCommon
 
+#include <array>
 #include <unordered_map>
 
 typedef struct{


### PR DESCRIPTION
Bug: https://bugs.gentoo.org/840586