### PR TITLE
Allow `vW:i` tag for wasp in SAM output

### DIFF
--- a/source/Parameters.cpp
+++ b/source/Parameters.cpp
@@ -880,13 +880,6 @@ void Parameters::inputParameters (int argInN, char* argIn[]) {//input parameters
         exitWithError(errOut.str(), std::cerr, inOut->logMain, EXIT_CODE_PARAMETER, *this);
     };
 
-     if (wasp.yes && outSAMtype.at(0)!="BAM") {
-        ostringstream errOut;
-        errOut <<"EXITING because of FATAL INPUT ERROR: --waspOutputMode requires output to BAM file\n";
-        errOut <<"SOLUTION: re-run STAR with --waspOutputMode ... and --outSAMtype BAM ... \n";
-        exitWithError(errOut.str(), std::cerr, inOut->logMain, EXIT_CODE_PARAMETER, *this);
-    };
-    
     //quantification parameters
     quant.yes=false;
     quant.geCount.yes=false;

--- a/source/Parameters_samAttributes.cpp
+++ b/source/Parameters_samAttributes.cpp
@@ -237,7 +237,6 @@ void Parameters::samAttributes(){//everything related to SAM attributes
     samAttrRequiresBAM(outSAMattrPresent.rB, "rB");
     samAttrRequiresBAM(outSAMattrPresent.vG, "vG");
     samAttrRequiresBAM(outSAMattrPresent.vA, "vA");
-    samAttrRequiresBAM(outSAMattrPresent.vW, "vW");
     samAttrRequiresBAM(outSAMattrPresent.GX, "GX");
     samAttrRequiresBAM(outSAMattrPresent.GN, "GN");
     

--- a/source/ReadAlign_outputTranscriptSAM.cpp
+++ b/source/ReadAlign_outputTranscriptSAM.cpp
@@ -337,6 +337,9 @@ uint ReadAlign::outputTranscriptSAM(Transcript const &trOut, uint nTrOut, uint i
                 case ATTR_vG:
                 case ATTR_vA:
                 case ATTR_vW:
+                    if (waspType!=-1)
+                        *outStream<< "\tvW:i:"  << (int32)waspType;
+                    break;
                 case ATTR_GX:
                 case ATTR_GN:                    
                     break;


### PR DESCRIPTION
Allowing wasp tags in SAM output seems straightforward (and seems to be identical after this modification to converting BAM to SAM). Maybe it was just not implemented, but I can't see any reason why such a tag would actually be problematic in SAM.

This PR only looks at a few code pathways, so probably many more tags/modes should be changed, but this addresses a common usecase. 