### PR TITLE
Bugfix: Resolve race condition with FIFO cleanup and child process termination

### DIFF
--- a/source/Parameters_closeReadsFiles.cpp
+++ b/source/Parameters_closeReadsFiles.cpp
@@ -2,11 +2,32 @@
 #include "ErrorWarning.h"
 #include <fstream>
 #include <sys/stat.h>
+#include <sys/wait.h>
 void Parameters::closeReadsFiles() {
     for (uint imate=0; imate<readFilesIn.size(); imate++) {//open readIn files
         if ( inOut->readIn[imate].is_open() )
             inOut->readIn[imate].close();
-        if (readFilesCommandPID[imate]>0)
-            kill(readFilesCommandPID[imate],SIGKILL);
+        if (readFilesCommandPID[imate]>0) {
+            kill(readFilesCommandPID[imate],SIGTERM);  // Use SIGTERM for graceful shutdown
+            int status;
+            waitpid(readFilesCommandPID[imate], &status, 0);  // Wait for process to terminate
+            
+            // Check if process had issues (but don't fail - this is cleanup)
+            if (WIFEXITED(status)) {
+                int exit_code = WEXITSTATUS(status);
+                if (exit_code != 0) {
+                    warningMessage("readFilesCommand process for mate " + to_string(imate+1) + 
+                                 " exited with non-zero code: " + to_string(exit_code), 
+                                 std::cerr, inOut->logMain, *this);
+                }
+            } else if (WIFSIGNALED(status)) {
+                int signal_num = WTERMSIG(status);
+                if (signal_num != SIGTERM) {  // Don't warn about our own SIGTERM
+                    warningMessage("readFilesCommand process for mate " + to_string(imate+1) + 
+                                 " was terminated by signal: " + to_string(signal_num), 
+                                 std::cerr, inOut->logMain, *this);
+                }
+            }
+        }
     };
 };

--- a/source/STAR.cpp
+++ b/source/STAR.cpp
@@ -292,6 +292,8 @@ int main(int argInN, char *argIn[])
     *P.inOut->logStdOut << timeMonthDayTime(g_statsAll.timeFinish) << " ..... finished successfully\n"
                         << flush;
 
+    P.closeReadsFiles(); // Clean up processes BEFORE removing files
+
     P.inOut->logMain << "ALL DONE!\n"
                      << flush;
     if (P.outTmpKeep == "None")
@@ -299,7 +301,6 @@ int main(int argInN, char *argIn[])
         sysRemoveDir(P.outFileTmp);
     };
 
-    P.closeReadsFiles(); // this will kill the readFilesCommand processes if necessary
     // genomeMain.~Genome(); //need explicit call because of the 'delete P.inOut' below, which will destroy P.inOut->logStdOut
     if (genomeMain.sharedMemory != NULL)
     { // need explicit call because this destructor will write to files which are deleted by 'delete P.inOut' below


### PR DESCRIPTION
# Problem Description

Users encountered a race condition where STAR would delete FIFO files while child processes (running samtools view via --readFilesCommand) were still writing to them. This manifested as the process leaving unclosed file descriptors. In lsof output, we see:

```
sh  1427  root  7r  unknown  /path/_STARtmp/tmp.fifo.read1 (deleted) (stat: No such file or directory)
```

The child process holds a file descriptor to a deleted FIFO, indicating improper synchronization between process termination and file cleanup.

# Root Cause Analysis

## Primary Issue: Incorrect Cleanup Ordering
The main problem was in STAR.cpp - the cleanup sequence was backwards:

```cpp
// BROKEN ORDER - deletes files while processes still running
if (P.outTmpKeep == "None") {
    sysRemoveDir(P.outFileTmp);      // Deletes FIFOs first
};
P.closeReadsFiles();                 // Cleans up processes after files gone
```

## Secondary Issue: Inadequate Process Synchronization

In Parameters_closeReadsFiles.cpp, the process cleanup was too aggressive:

```cpp
// OLD CODE - no synchronization
kill(readFilesCommandPID[imate], SIGKILL);  // Forceful kill, returns immediately
// No waiting - function returns while process may still be dying
```
# The Race Condition Window

```cpp
// OLD CODE - Race condition
kill(readFilesCommandPID[imate], SIGKILL);  // Process is dying...
// Function returns immediately, no synchronization
// Meanwhile: sysRemoveDir() deletes FIFOs while process still holds FDs
```

## Timeline:
- T0: STAR finishes processing, enters cleanup
- T1: sysRemoveDir(P.outFileTmp) deletes FIFO files while samtools view still running
- T2: P.closeReadsFiles() sends SIGKILL to processes writing to already-deleted FIFOs
- T3: Child processes hold file descriptors to deleted files during termination

# Solution

## Fix 1: Correct Cleanup Ordering (STAR.cpp)
```cpp
// FIXED ORDER - processes first, then files
P.closeReadsFiles();                 //  Clean up processes FIRST
if (P.outTmpKeep == "None") {
    sysRemoveDir(P.outFileTmp);      //  THEN delete files
};
```

## Fix 2: Proper Process Synchronization (Parameters_closeReadsFiles.cpp)

```cpp
// NEW CODE - synchronized cleanup
kill(readFilesCommandPID[imate], SIGTERM);      // Graceful shutdown request
int status;
waitpid(readFilesCommandPID[imate], &status, 0); // Wait for actual termination
```

# Why This Fixes The Race Condition

1. Ordering Fix (Primary): Directory removal only happens after all processes are confirmed terminated
2. SIGTERM vs SIGKILL: Allows graceful shutdown instead of forced termination
3. waitpid() Synchronization: Guarantees child processes have fully released file descriptors before cleanup
4. Status Checking: Provides visibility into samtools failures for better debugging


# Impact

- Eliminates race condition: No more deleted FIFOs with active file descriptors
- Better error reporting: Users can see if samtools view failed on their BAM files
- Maintains functionality: No change to STAR's core behavior or performance
- Defensive programming: Handles edge cases gracefully

The combination of correct ordering and proper synchronization ensures that sysRemoveDir() only executes after all child processes have properly released their file descriptors, eliminating the race condition entirely.

