### PR TITLE
Improve genomeGenerate multicore index build performance

### DIFF
--- a/extras/tests/scripts/benchmarkGenomeGenerate.sh
+++ b/extras/tests/scripts/benchmarkGenomeGenerate.sh
@@ -1,0 +1,436 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Genome-generation benchmark and idempotence harness.
+#
+# Typical use after a genomeGenerate optimization:
+#   make -C source STAR
+#   BASELINE_STAR_BIN=/path/to/baseline/STAR THREADS="1 4 8 16" \
+#       extras/tests/scripts/benchmarkGenomeGenerate.sh
+#
+# To compare against both a recent optimized baseline and a raw/base STAR build:
+#   BASELINE_STAR_BIN=/path/to/optimized/STAR BASE_STAR_BIN=/path/to/base/STAR \
+#       THREADS="64 128" extras/tests/scripts/benchmarkGenomeGenerate.sh
+#
+# For performance measurements, prefer a realistic FASTA:
+#   BENCH_FASTA=/path/to/genome.fa LIMIT_GENOME_GENERATE_RAM=31000000000 \
+#       THREADS="1 4 8 16 32" extras/tests/scripts/benchmarkGenomeGenerate.sh
+#
+# To benchmark a splice-junction-augmented genome index:
+#   BENCH_FASTA=/path/to/genome.fa BENCH_GTF=/path/to/genes.gtf SJDB_OVERHANG=93 \
+#       THREADS="32 64" extras/tests/scripts/benchmarkGenomeGenerate.sh
+#
+# To pass multiple FASTA files, use a space-separated list:
+#   BENCH_FASTA_FILES="/path/to/genome.fa /path/to/spikeins.fa" ...
+#
+# The built-in FASTA is intentionally tiny. It is for fast byte-identity checks,
+# not for meaningful wall-clock speedup measurements.
+# Use SYNTHETIC_REPEAT=N to scale it up deterministically when BENCH_FASTA is
+# not set.
+
+script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+repo_root="$(cd "${script_dir}/../../.." && pwd)"
+
+star_bin="${STAR_BIN:-${repo_root}/source/STAR}"
+baseline_star_bin="${BASELINE_STAR_BIN:-}"
+base_star_bin="${BASE_STAR_BIN:-}"
+out_root="${OUT_DIR:-/tmp/star-genome-generate-bench.$(date +%Y%m%d_%H%M%S).$$}"
+threads_list="${THREADS:-1 4}"
+runs_per_thread="${RUNS_PER_THREAD:-2}"
+baseline_runs_per_thread="${BASELINE_RUNS_PER_THREAD:-${runs_per_thread}}"
+base_runs_per_thread="${BASE_RUNS_PER_THREAD:-${baseline_runs_per_thread}}"
+genome_saindex_nbases="${GENOME_SAINDEX_NBASES:-2}"
+genome_chrbin_nbits="${GENOME_CHRBIN_NBITS:-4}"
+limit_genome_ram="${LIMIT_GENOME_GENERATE_RAM:-20000}"
+bench_gtf="${BENCH_GTF:-}"
+sjdb_overhang="${SJDB_OVERHANG:-}"
+time_bin="${TIME_BIN:-/usr/bin/time}"
+synthetic_repeat="${SYNTHETIC_REPEAT:-1}"
+iostat_bin="${IOSTAT_BIN:-$(command -v iostat || true)}"
+iostat_interval="${IOSTAT_INTERVAL:-5}"
+cpu_sample_interval="${CPU_SAMPLE_INTERVAL:-1}"
+
+if [[ ! -x "${star_bin}" ]]; then
+    echo "ERROR: STAR_BIN is not executable: ${star_bin}" >&2
+    exit 1
+fi
+
+if [[ -n "${baseline_star_bin}" && ! -x "${baseline_star_bin}" ]]; then
+    echo "ERROR: BASELINE_STAR_BIN is not executable: ${baseline_star_bin}" >&2
+    exit 1
+fi
+
+if [[ -n "${base_star_bin}" && ! -x "${base_star_bin}" ]]; then
+    echo "ERROR: BASE_STAR_BIN is not executable: ${base_star_bin}" >&2
+    exit 1
+fi
+
+if [[ ! -x "${time_bin}" ]]; then
+    echo "ERROR: TIME_BIN is not executable: ${time_bin}" >&2
+    exit 1
+fi
+
+if [[ -n "${bench_gtf}" && ! -r "${bench_gtf}" ]]; then
+    echo "ERROR: BENCH_GTF is not readable: ${bench_gtf}" >&2
+    exit 1
+fi
+
+if [[ -n "${sjdb_overhang}" && -z "${bench_gtf}" ]]; then
+    echo "ERROR: SJDB_OVERHANG requires BENCH_GTF" >&2
+    exit 1
+fi
+
+mkdir -p "${out_root}"
+out_root="$(cd "${out_root}" && pwd)"
+
+fasta="${BENCH_FASTA:-${out_root}/synthetic.fa}"
+bench_fasta_files="${BENCH_FASTA_FILES:-${BENCH_FASTA:-}}"
+fasta_files=()
+
+make_synthetic_fasta() {
+    local out_fasta="$1"
+    local repeat_i
+    {
+        echo ">chrA"
+        for ((repeat_i=0; repeat_i<synthetic_repeat; repeat_i++)); do
+            echo "ACGTTGCACCATGGTACGATCGTACGTTAGCTAGGCTAACCGTTAACGATGCTAGCTTACGATCGATGCGTACCATCGTTAACG"
+            echo "TGCAACGGTACCTAGCATCGATCGTAGGCTAACGTACGATGCTTACCGATCGTAGCTAGCATGCTAGGATCCGATCGTACGTAA"
+            echo "GATCGTACGTTAGCATGCCGTAACGATCGTAGCTAACGTTGCACCATGGTACGATCGTACGTTAGCTAGGCTAACCGTTAACGA"
+            echo "TCGATGCGTACCATCGTTAACGTGCAACGGTACCTAGCATCGATCGTAGGCTAACGTACGATGCTTACCGATCGTAGCTAGCAT"
+            echo "GCTAGGATCCGATCGTACGTAAGATCGTACGTTAGCATGCCGTAACGATCGTAGCTAACGTTGCACCATGGTACGATCGTACGT"
+            echo "TAGCTAGGCTAACCGTTAACGATGCTAGCTTACGATCGATGCGTACCATCGTTAACGTGCAACGGTACCTAGCATCGATCGTAG"
+            echo "GCTAACGTACGATGCTTACCGATCGTAGCTAGCATGCTAGGATCCGATCGTACGTAAGATCGTACGTTAGCATGCCGTAACGAT"
+            echo "CGTAGCTAACGTTGCACCATGGTACGATCGTACGTTAGCTAGGCTAACCGTTAACGATGCTAGCTTACGATCGATGCGTACCAT"
+            echo "CGTTAACGTGCAACGGTACCTAGCATCGATCGTAGGCTAACGTACGATGCTTACCGATCGTAGCTAGCATGCTAGGATCCGATC"
+            echo "GTACGTAAGATCGTACGTTAGCATGCCGTAACGATCGTAGCTAACGTTGCACCATGGTACGATCGTACGTTAGCTAGGCTAAC"
+        done
+        echo ">chrB"
+        for ((repeat_i=0; repeat_i<synthetic_repeat; repeat_i++)); do
+            echo "TTGACCGTAGCTAACGATCGTACCGTTAGCATCGATGCTAACCGTAGGCTTACGATCGTAGCATGCGTTAACCGATCGTACCTA"
+            echo "GCTAACGTTAGGCTACGATGCTAGCATCGTTAACGATCCGTAGCTTACGTTGCATCGATGGTACCGTAGCATGCTAACGATCGT"
+            echo "ACCGTTAGCATCGATGCTAACCGTAGGCTTACGATCGTAGCATGCGTTAACCGATCGTACCTAGCTAACGTTAGGCTACGATGC"
+            echo "TAGCATCGTTAACGATCCGTAGCTTACGTTGCATCGATGGTACCGTAGCATGCTAACGATCGTTTGACCGTAGCTAACGATCGT"
+            echo "ACCGTTAGCATCGATGCTAACCGTAGGCTTACGATCGTAGCATGCGTTAACCGATCGTACCTAGCTAACGTTAGGCTACGATGC"
+            echo "TAGCATCGTTAACGATCCGTAGCTTACGTTGCATCGATGGTACCGTAGCATGCTAACGATCGTTTGACCGTAGCTAACGATCGT"
+            echo "ACCGTTAGCATCGATGCTAACCGTAGGCTTACGATCGTAGCATGCGTTAACCGATCGTACCTAGCTAACGTTAGGCTACGATGC"
+            echo "TAGCATCGTTAACGATCCGTAGCTTACGTTGCATCGATGGTACCGTAGCATGCTAACGATCGTTTGACCGTAGCTAACGATCGT"
+        done
+    } > "${out_fasta}"
+}
+
+if [[ -z "${bench_fasta_files}" ]]; then
+    make_synthetic_fasta "${fasta}"
+    fasta_files=("${fasta}")
+else
+    read -r -a fasta_files <<< "${bench_fasta_files}"
+fi
+
+for fasta_file in "${fasta_files[@]}"; do
+    if [[ ! -r "${fasta_file}" ]]; then
+        echo "ERROR: FASTA is not readable: ${fasta_file}" >&2
+        exit 1
+    fi
+done
+
+if [[ "${#fasta_files[@]}" -eq 0 ]]; then
+    echo "ERROR: no FASTA files were provided" >&2
+    exit 1
+fi
+
+extract_stage_times() {
+    local log_path="$1"
+    local stage_path="$2"
+    local log_year
+    log_year="$(date +%Y)"
+
+    awk -v year="${log_year}" '
+        BEGIN {
+            month["Jan"]=1; month["Feb"]=2; month["Mar"]=3; month["Apr"]=4;
+            month["May"]=5; month["Jun"]=6; month["Jul"]=7; month["Aug"]=8;
+            month["Sep"]=9; month["Oct"]=10; month["Nov"]=11; month["Dec"]=12;
+            print "stage\tstart_time\tend_time\tseconds";
+        }
+
+        function timestamp(line, mon, day, hour, minute, second) {
+            mon=substr(line,1,3);
+            if (!(mon in month)) {
+                return "";
+            }
+            day=substr(line,5,2)+0;
+            hour=substr(line,8,2)+0;
+            minute=substr(line,11,2)+0;
+            second=substr(line,14,2)+0;
+            return mktime(year " " month[mon] " " day " " hour " " minute " " second);
+        }
+
+        function mark(key,line, parsed_time) {
+            if (!(key in times)) {
+                parsed_time=timestamp(line);
+                if (parsed_time!="") {
+                    times[key]=parsed_time;
+                    labels[key]=substr(line,1,15);
+                }
+            }
+        }
+
+        function emit(stage,start_key,end_key) {
+            if ((start_key in times) && (end_key in times)) {
+                printf "%s\t%s\t%s\t%d\n", stage, labels[start_key], labels[end_key], times[end_key]-times[start_key];
+            } else {
+                printf "%s\tNA\tNA\tNA\n", stage;
+            }
+        }
+
+        /starting to sort Suffix Array/ { mark("sa_sort_start",$0); next }
+        /sorting Suffix Array chunks/ { mark("sa_chunk_sort",$0); next }
+        /packing SA from RAM chunks|loading chunks from disk, packing SA/ { mark("sa_pack",$0); next }
+        /finished generating suffix array/ { mark("sa_done",$0); next }
+        /generating Suffix Array index/ { mark("saindex_start",$0); next }
+        /completed Suffix Array index/ { mark("saindex_done",$0); next }
+        /Finished preparing junctions/ { mark("sj_prepare_done",$0); next }
+        /inserting junctions into the genome indices/ { mark("sj_insert_start",$0); next }
+        /Finished SA search:/ { mark("sj_sa_search_done",$0); next }
+        /Finished sorting SA indicesL/ { mark("sj_sort_done",$0); next }
+        /Finished inserting junction indices/ { mark("sj_insert_indices_done",$0); next }
+        /Finished SAi$/ { mark("sj_sai_done",$0); next }
+        /writing Genome to disk/ { mark("write_genome_start",$0); next }
+        /writing Suffix Array to disk/ { mark("write_sa_start",$0); next }
+        /writing SAindex to disk/ { mark("write_saindex_start",$0); next }
+        /finished successfully/ { mark("finish_success",$0); next }
+
+        END {
+            emit("sa_prefix_plan_seconds","sa_sort_start","sa_chunk_sort");
+            emit("sa_chunk_sort_seconds","sa_chunk_sort","sa_pack");
+            emit("sa_pack_seconds","sa_pack","sa_done");
+            emit("saindex_seconds","saindex_start","saindex_done");
+            emit("sj_prepare_seconds","saindex_done","sj_prepare_done");
+            emit("sj_sa_search_seconds","sj_insert_start","sj_sa_search_done");
+            emit("sj_sort_seconds","sj_sa_search_done","sj_sort_done");
+            emit("sj_insert_indices_seconds","sj_sort_done","sj_insert_indices_done");
+            emit("sj_sai_seconds","sj_insert_indices_done","sj_sai_done");
+            emit("write_genome_seconds","write_genome_start","write_sa_start");
+            emit("write_sa_seconds","write_sa_start","write_saindex_start");
+            emit("write_saindex_seconds","write_saindex_start","finish_success");
+        }
+    ' "${log_path}" > "${stage_path}"
+}
+
+stage_metric() {
+    local stage_path="$1"
+    local stage_name="$2"
+    awk -F '\t' -v stage="${stage_name}" '$1==stage {print $4; found=1; exit} END {if (!found) print "NA"}' "${stage_path}"
+}
+
+summary="${out_root}/summary.tsv"
+printf "label\tthreads\trun\treal_seconds\tuser_seconds\tsys_seconds\tmax_rss_kb\tsa_chunk_fill_strategy\tsa_chunk_sort_prefix_length\tsa_chunk_sort_granularity\tsa_chunk_storage_strategy\tsa_chunk_system_available_bytes\tsa_chunk_ram_peak_bytes\tsa_all_scatter_available_bytes\tsa_all_scatter_required_bytes\tsa_batched_fill_batches\tsaindex_traversal_strategy\tsaindex_event_count\tsa_prefix_plan_seconds\tsa_chunk_sort_seconds\tsa_pack_seconds\tsaindex_seconds\tsj_prepare_seconds\tsj_sa_search_seconds\tsj_sort_seconds\tsj_insert_indices_seconds\tsj_sai_seconds\twrite_genome_seconds\twrite_sa_seconds\twrite_saindex_seconds\tstage_times_log\tgenome_dir\tio_log\tcpu_log\n" > "${summary}"
+
+run_dir=""
+
+run_generate() {
+    local label="$1"
+    local bin="$2"
+    local threads="$3"
+    local run_id="$4"
+    run_dir="${out_root}/${label}_t${threads}_r${run_id}"
+    local log_file="${out_root}/${label}_t${threads}_r${run_id}.log"
+    local time_file="${out_root}/${label}_t${threads}_r${run_id}.time"
+    local io_file="${out_root}/${label}_t${threads}_r${run_id}.iostat"
+    local cpu_file="${out_root}/${label}_t${threads}_r${run_id}.threads"
+    local stage_file="${out_root}/${label}_t${threads}_r${run_id}.stage_times.tsv"
+    local iostat_pid=""
+    local cpu_sampler_pid=""
+    local star_wrapper_pid=""
+
+    if [[ -e "${run_dir}" ]]; then
+        echo "ERROR: output directory already exists: ${run_dir}" >&2
+        exit 1
+    fi
+    mkdir -p "${run_dir}"
+
+    if [[ -n "${iostat_bin}" && -x "${iostat_bin}" ]]; then
+        "${iostat_bin}" -xz "${iostat_interval}" > "${io_file}" 2>&1 &
+        iostat_pid="$!"
+    else
+        printf "iostat unavailable\n" > "${io_file}"
+    fi
+
+    printf "timestamp\tpid\ttid\tpsr\tpcpu\tstat\tcomm\targs\n" > "${cpu_file}"
+
+    local star_args=(
+        --runMode genomeGenerate
+        --runThreadN "${threads}"
+        --genomeDir "${run_dir}"
+        --genomeFastaFiles "${fasta_files[@]}"
+        --genomeSAindexNbases "${genome_saindex_nbases}"
+        --genomeChrBinNbits "${genome_chrbin_nbits}"
+        --limitGenomeGenerateRAM "${limit_genome_ram}"
+    )
+
+    if [[ -n "${bench_gtf}" ]]; then
+        star_args+=(--sjdbGTFfile "${bench_gtf}")
+    fi
+
+    if [[ -n "${sjdb_overhang}" ]]; then
+        star_args+=(--sjdbOverhang "${sjdb_overhang}")
+    fi
+
+    set +e
+    (
+        cd "${out_root}"
+        "${time_bin}" -f "%e\t%U\t%S\t%M" -o "${time_file}" \
+            "${bin}" "${star_args[@]}" \
+            > "${log_file}" 2>&1
+    ) &
+    star_wrapper_pid="$!"
+
+    (
+        while kill -0 "${star_wrapper_pid}" 2>/dev/null; do
+            local_now="$(date -Ins)"
+            ps -eLo pid,tid,psr,pcpu,stat,comm,args \
+                | awk -v now="${local_now}" -v dir="${run_dir}" \
+                    'NR>1 && $6=="STAR" && index($0,dir)>0 {printf "%s\t%s\t%s\t%s\t%s\t%s\t%s\t", now, $1, $2, $3, $4, $5, $6; for (i=7; i<=NF; i++) printf "%s%s", $i, (i<NF ? OFS : ORS)}' \
+                >> "${cpu_file}"
+            sleep "${cpu_sample_interval}"
+        done
+    ) &
+    cpu_sampler_pid="$!"
+
+    wait "${star_wrapper_pid}"
+    local star_status="$?"
+    set -e
+
+    if [[ -n "${cpu_sampler_pid}" ]]; then
+        kill "${cpu_sampler_pid}" 2>/dev/null || true
+        wait "${cpu_sampler_pid}" 2>/dev/null || true
+    fi
+
+    if [[ -n "${iostat_pid}" ]]; then
+        kill "${iostat_pid}" 2>/dev/null || true
+        wait "${iostat_pid}" 2>/dev/null || true
+    fi
+
+    if [[ "${star_status}" -ne 0 ]]; then
+        echo "ERROR: STAR genomeGenerate failed for ${label} t${threads} run ${run_id}; see ${log_file}" >&2
+        exit "${star_status}"
+    fi
+
+    extract_stage_times "${run_dir}/Log.out" "${stage_file}"
+
+    local real_s user_s sys_s max_rss sa_chunk_fill_strategy sa_chunk_sort_prefix_length sa_chunk_sort_granularity sa_chunk_storage_strategy sa_chunk_system_available_bytes sa_chunk_ram_peak_bytes sa_all_scatter_available_bytes sa_all_scatter_required_bytes sa_batched_fill_batches saindex_traversal_strategy saindex_event_count
+    local sa_prefix_plan_seconds sa_chunk_sort_seconds sa_pack_seconds saindex_seconds sj_prepare_seconds sj_sa_search_seconds sj_sort_seconds sj_insert_indices_seconds sj_sai_seconds write_genome_seconds write_sa_seconds write_saindex_seconds
+    read -r real_s user_s sys_s max_rss < "${time_file}"
+    sa_chunk_fill_strategy="$(awk -F': ' '/SA chunk fill strategy:/ {print $2; found=1; exit} END {if (!found) print "NA"}' "${run_dir}/Log.out")"
+    sa_chunk_sort_prefix_length="$(awk -F': ' '/SA chunk sort prefix length:/ {print $2; found=1; exit} END {if (!found) print "NA"}' "${run_dir}/Log.out")"
+    sa_chunk_sort_granularity="$(awk -F': ' '/SA chunk sort granularity:/ {print $2; found=1; exit} END {if (!found) print "NA"}' "${run_dir}/Log.out")"
+    sa_chunk_storage_strategy="$(awk -F': ' '/SA chunk storage strategy:/ {print $2; found=1; exit} END {if (!found) print "NA"}' "${run_dir}/Log.out")"
+    sa_chunk_system_available_bytes="$(awk '/SA chunk system available bytes:/ {gsub(/;/,""); print $6; found=1; exit} END {if (!found) print "NA"}' "${run_dir}/Log.out")"
+    sa_chunk_ram_peak_bytes="$(awk '/SA chunk retained bytes:/ {gsub(/;/,""); print $9; found=1; exit} END {if (!found) print "NA"}' "${run_dir}/Log.out")"
+    read -r sa_all_scatter_available_bytes sa_all_scatter_required_bytes < <(awk '/SA chunk all-scatter available bytes:/ {gsub(/;/,""); print $6, $10; found=1; exit} END {if (!found) print "NA NA"}' "${run_dir}/Log.out")
+    sa_batched_fill_batches="$(awk -F': ' '/SA chunk estimated batched-fill batches:/ {print $2; found=1; exit} END {if (!found) print "NA"}' "${run_dir}/Log.out")"
+    saindex_traversal_strategy="$(awk -F': ' '/SAindex traversal strategy:/ {print $2; found=1; exit} END {if (!found) print "NA"}' "${run_dir}/Log.out")"
+    saindex_event_count="$(awk -F': ' '/SAindex event count:/ {print $2; found=1; exit} END {if (!found) print "NA"}' "${run_dir}/Log.out")"
+    sa_prefix_plan_seconds="$(stage_metric "${stage_file}" "sa_prefix_plan_seconds")"
+    sa_chunk_sort_seconds="$(stage_metric "${stage_file}" "sa_chunk_sort_seconds")"
+    sa_pack_seconds="$(stage_metric "${stage_file}" "sa_pack_seconds")"
+    saindex_seconds="$(stage_metric "${stage_file}" "saindex_seconds")"
+    sj_prepare_seconds="$(stage_metric "${stage_file}" "sj_prepare_seconds")"
+    sj_sa_search_seconds="$(stage_metric "${stage_file}" "sj_sa_search_seconds")"
+    sj_sort_seconds="$(stage_metric "${stage_file}" "sj_sort_seconds")"
+    sj_insert_indices_seconds="$(stage_metric "${stage_file}" "sj_insert_indices_seconds")"
+    sj_sai_seconds="$(stage_metric "${stage_file}" "sj_sai_seconds")"
+    write_genome_seconds="$(stage_metric "${stage_file}" "write_genome_seconds")"
+    write_sa_seconds="$(stage_metric "${stage_file}" "write_sa_seconds")"
+    write_saindex_seconds="$(stage_metric "${stage_file}" "write_saindex_seconds")"
+    printf "%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\n" \
+        "${label}" "${threads}" "${run_id}" "${real_s}" "${user_s}" "${sys_s}" "${max_rss}" \
+        "${sa_chunk_fill_strategy}" "${sa_chunk_sort_prefix_length}" "${sa_chunk_sort_granularity}" \
+        "${sa_chunk_storage_strategy}" "${sa_chunk_system_available_bytes}" "${sa_chunk_ram_peak_bytes}" \
+        "${sa_all_scatter_available_bytes}" "${sa_all_scatter_required_bytes}" "${sa_batched_fill_batches}" "${saindex_traversal_strategy}" "${saindex_event_count}" \
+        "${sa_prefix_plan_seconds}" "${sa_chunk_sort_seconds}" "${sa_pack_seconds}" "${saindex_seconds}" \
+        "${sj_prepare_seconds}" "${sj_sa_search_seconds}" "${sj_sort_seconds}" "${sj_insert_indices_seconds}" "${sj_sai_seconds}" \
+        "${write_genome_seconds}" "${write_sa_seconds}" "${write_saindex_seconds}" \
+        "${stage_file}" "${run_dir}" "${io_file}" "${cpu_file}" >> "${summary}"
+}
+
+compare_core_outputs() {
+    local dir_a="$1"
+    local dir_b="$2"
+    local label="$3"
+    local file
+
+    for file in Genome SA SAindex chrName.txt chrStart.txt chrLength.txt chrNameLength.txt sjdbList.out.tab; do
+        if [[ -e "${dir_a}/${file}" || -e "${dir_b}/${file}" ]]; then
+            if ! cmp -s "${dir_a}/${file}" "${dir_b}/${file}"; then
+                echo "ERROR: ${label}: ${file} differs between ${dir_a} and ${dir_b}" >&2
+                exit 1
+            fi
+        fi
+    done
+}
+
+first_candidate_dir=""
+
+for threads in ${threads_list}; do
+    candidate_reference_dir=""
+
+    run_id=1
+    while [[ "${run_id}" -le "${runs_per_thread}" ]]; do
+        run_generate candidate "${star_bin}" "${threads}" "${run_id}"
+        candidate_dir="${run_dir}"
+
+        if [[ -z "${candidate_reference_dir}" ]]; then
+            candidate_reference_dir="${candidate_dir}"
+        else
+            compare_core_outputs "${candidate_reference_dir}" "${candidate_dir}" "candidate repeat t${threads}"
+        fi
+
+        run_id=$((run_id+1))
+    done
+
+    if [[ -z "${first_candidate_dir}" ]]; then
+        first_candidate_dir="${candidate_reference_dir}"
+    else
+        compare_core_outputs "${first_candidate_dir}" "${candidate_reference_dir}" "candidate thread-count t${threads}"
+    fi
+
+    if [[ -n "${baseline_star_bin}" ]]; then
+        baseline_reference_dir=""
+        run_id=1
+        while [[ "${run_id}" -le "${baseline_runs_per_thread}" ]]; do
+            run_generate baseline "${baseline_star_bin}" "${threads}" "${run_id}"
+            baseline_dir="${run_dir}"
+
+            if [[ -z "${baseline_reference_dir}" ]]; then
+                baseline_reference_dir="${baseline_dir}"
+            else
+                compare_core_outputs "${baseline_reference_dir}" "${baseline_dir}" "baseline repeat t${threads}"
+            fi
+
+            run_id=$((run_id+1))
+        done
+
+        compare_core_outputs "${baseline_reference_dir}" "${candidate_reference_dir}" "baseline vs candidate t${threads}"
+    fi
+
+    if [[ -n "${base_star_bin}" ]]; then
+        base_reference_dir=""
+        run_id=1
+        while [[ "${run_id}" -le "${base_runs_per_thread}" ]]; do
+            run_generate base "${base_star_bin}" "${threads}" "${run_id}"
+            base_dir="${run_dir}"
+
+            if [[ -z "${base_reference_dir}" ]]; then
+                base_reference_dir="${base_dir}"
+            else
+                compare_core_outputs "${base_reference_dir}" "${base_dir}" "base repeat t${threads}"
+            fi
+
+            run_id=$((run_id+1))
+        done
+
+        compare_core_outputs "${base_reference_dir}" "${candidate_reference_dir}" "base vs candidate t${threads}"
+    fi
+done
+
+echo "Benchmark complete: ${out_root}"
+echo "Summary: ${summary}"

--- a/source/Genome_genomeGenerate.cpp
+++ b/source/Genome_genomeGenerate.cpp
@@ -1,4 +1,6 @@
 #include <cmath>
+#include <cstdlib>
+#include <new>
 
 #include "Genome.h"
 
@@ -25,18 +27,34 @@
 char* globalG;
 uint globalL;
 
+static uint systemAvailableMemoryBytes()
+{
+#ifdef __linux__
+    ifstream memInfo("/proc/meminfo");
+    string field, unit;
+    uint value=0;
 
-inline int funCompareSuffixes ( const void *a, const void *b){
+    while (memInfo >> field >> value >> unit) {
+        if (field=="MemAvailable:") {
+            return value*1024LLU;
+        };
+    };
+#endif
+    return 0;
+};
 
-    uint *ga=(uint*)((globalG-7LLU)+(*((uint*)a)));
-    uint *gb=(uint*)((globalG-7LLU)+(*((uint*)b)));
+
+inline int funCompareSuffixesFromWord ( const void *a, const void *b, uint wordStart){
+
+    uint *ga=(uint*)((globalG-7LLU)+(*((uint*)a)))-wordStart;
+    uint *gb=(uint*)((globalG-7LLU)+(*((uint*)b)))-wordStart;
 
     uint jj=0;
     int  ii=0;
     uint va=0,vb=0;
     uint8 *va1, *vb1;
 
-    while (jj < globalL) {
+    while (jj+wordStart < globalL) {
         va=*(ga-jj);
         vb=*(gb-jj);
 
@@ -88,11 +106,56 @@ inline int funCompareSuffixes ( const void *a, const void *b){
     };
 };
 
+inline int funCompareSuffixes ( const void *a, const void *b){
+    return funCompareSuffixesFromWord(a,b,0);
+};
+
+inline int funCompareSuffixesSkipFirstWord ( const void *a, const void *b){
+    return funCompareSuffixesFromWord(a,b,1);
+};
+
 inline uint funG2strLocus (uint SAstr, uint const N, char const GstrandBit, uint const GstrandMask) {
     bool strandG = (SAstr>>GstrandBit) == 0;
     SAstr &= GstrandMask;
     if ( !strandG ) SAstr += N;
     return SAstr;
+};
+
+inline uint funSAsortPrefix(char* G, uint ii, uint prefixLength) {
+    uint prefix=0;
+    for (uint jj=0; jj<prefixLength; jj++) {
+        uint g=(uint) G[ii-jj];
+        if (g>5) g=5;
+        prefix=prefix*6+g;
+    };
+    return prefix;
+};
+
+inline uint funSAsortPrefixAtOffset(char* G, uint ii, uint offset, uint prefixLength) {
+    uint prefix=0;
+    for (uint jj=0; jj<prefixLength; jj++) {
+        uint g=(uint) G[ii-offset-jj];
+        if (g>5) g=5;
+        prefix=prefix*6+g;
+    };
+    return prefix;
+};
+
+inline bool funSAsortPrefixFirstWordHas5(uint prefix, uint prefixLength) {
+    uint wordBases=(uint) sizeof(uint);
+    if (prefixLength>wordBases) {
+        for (uint jj=0; jj<prefixLength-wordBases; jj++) {
+            prefix /= 6;
+        };
+        prefixLength=wordBases;
+    };
+    for (uint jj=0; jj<prefixLength; jj++) {
+        if (prefix % 6 == 5) {
+            return true;
+        };
+        prefix /= 6;
+    };
+    return false;
 };
 
 void Genome::genomeGenerate() {
@@ -217,16 +280,53 @@ void Genome::genomeGenerate() {
         };
         globalG=G;
         globalL=pGe.gSuffixLengthMax/sizeof(uint);
-        //count the number of indices with 4nt prefix
-        uint indPrefN=1LLU << 16;
+        // Count sort prefixes over STAR's 0..5 genome alphabet.
+        uint indPrefLen=6;
+        const uint64 saAvailableBytesForPrefix=P.limitGenomeGenerateRAM>nG1alloc ? P.limitGenomeGenerateRAM-nG1alloc : 0;
+        if (P.runThreadN>=16 && nGenome>=50000000) {
+            uint indPrefN8=1;
+            for (uint ii=0;ii<8;ii++) indPrefN8 *= 6;
+            const uint64 indPrefTempBytes8=(uint64) P.runThreadN*indPrefN8*2*sizeof(uint) + (indPrefN8+1)*sizeof(uint);
+            if (indPrefTempBytes8 < saAvailableBytesForPrefix/4) {
+                indPrefLen=8;
+            };
+        };
+        uint indPrefN=1;
+        for (uint ii=0;ii<indPrefLen;ii++) indPrefN *= 6;
         uint* indPrefCount = new uint [indPrefN];
         memset(indPrefCount,0,indPrefN*sizeof(indPrefCount[0]));
+        const bool saSortProfile=getenv("STAR_PROFILE_SA_SORT")!=NULL;
         nSA=0;
         for (uint ii=0;ii<2*nGenome;ii+=pGe.gSAsparseD) {
             if (G[ii]<4) {
-                uint p1=(G[ii]<<12) + (G[ii-1]<<8) + (G[ii-2]<<4) + G[ii-3];
+                uint p1=funSAsortPrefix(G,ii,indPrefLen);
                 indPrefCount[p1]++;
                 nSA++;
+            };
+        };
+
+        uint indPrefEmptyN=0;
+        uint indPrefSingletonN=0;
+        uint indPrefNonEmptyN=0;
+        uint indPrefSortableN=0;
+        uint indPrefMaxCount=0;
+        uint indPrefMaxIndex=0;
+        if (saSortProfile) {
+            for (uint ii=0; ii<indPrefN; ii++) {
+                if (indPrefCount[ii]==0) {
+                    indPrefEmptyN++;
+                } else {
+                    indPrefNonEmptyN++;
+                    if (indPrefCount[ii]==1) {
+                        indPrefSingletonN++;
+                    } else {
+                        indPrefSortableN++;
+                    };
+                    if (indPrefCount[ii]>indPrefMaxCount) {
+                        indPrefMaxCount=indPrefCount[ii];
+                        indPrefMaxIndex=ii;
+                    };
+                };
             };
         };
 
@@ -254,44 +354,393 @@ void Genome::genomeGenerate() {
         indPrefStart[saChunkN]=indPrefN+1;
         indPrefChunkCount[saChunkN-1]=chunkSize1;
 
+        uint* saChunkStart = new uint [saChunkN+1];
+        saChunkStart[0]=0;
+        for (uint iChunk=0; iChunk<saChunkN; iChunk++) {
+            saChunkStart[iChunk+1]=saChunkStart[iChunk]+indPrefChunkCount[iChunk];
+        };
+
         P.inOut->logMain  << "Number of chunks: " << saChunkN <<";   chunks size limit: " << saChunkSize*8 <<" bytes\n" <<flush;
 
         time ( &rawTime );
-        P.inOut->logMain     << timeMonthDayTime(rawTime) <<" ... sorting Suffix Array chunks and saving them to disk...\n" <<flush;
-        *P.inOut->logStdOut  << timeMonthDayTime(rawTime) <<" ... sorting Suffix Array chunks and saving them to disk...\n" <<flush;
+        P.inOut->logMain     << timeMonthDayTime(rawTime) <<" ... sorting Suffix Array chunks...\n" <<flush;
+        *P.inOut->logStdOut  << timeMonthDayTime(rawTime) <<" ... sorting Suffix Array chunks...\n" <<flush;
 
-        #pragma omp parallel for num_threads(P.runThreadN) ordered schedule(dynamic,1)
-        for (int iChunk=0; iChunk < (int) saChunkN; iChunk++) {//start the chunk cycle: sort each chunk with qsort and write to a file
-            uint* saChunk=new uint [indPrefChunkCount[iChunk]];//allocate local array for each chunk
-            for (uint ii=0,jj=0;ii<2*nGenome;ii+=pGe.gSAsparseD) {//fill the chunk with SA indices
-                if (G[ii]<4) {
-                    uint p1=(G[ii]<<12) + (G[ii-1]<<8) + (G[ii-2]<<4) + G[ii-3];
-                    if (p1>=indPrefStart[iChunk] && p1<indPrefStart[iChunk+1]) {
-                        saChunk[jj]=ii;
-                        jj++;
-                    };
-                    //TODO: if (jj==indPrefChunkCount[iChunk]) break;
+        const uint genomeScanN=(2*nGenome+pGe.gSAsparseD-1)/pGe.gSAsparseD;
+        const uint64 saAvailableBytes=P.limitGenomeGenerateRAM>nG1alloc ? P.limitGenomeGenerateRAM-nG1alloc : 0;
+        const uint64 saAllChunkScatterBytes=nSA*sizeof(uint) + (uint64) P.runThreadN*indPrefN*2*sizeof(uint) + (indPrefN+1)*sizeof(uint) + (saChunkN+1)*sizeof(uint);
+        const uint saChunkBatchSize=max(saChunkSize*(uint) P.runThreadN,saChunkSize);
+        uint saChunkBatchN=0;
+        if (P.runThreadN>=16 && saChunkN>1) {
+            uint iChunkBatch=0;
+            while (iChunkBatch<saChunkN) {
+                uint iChunkBatchNext=iChunkBatch;
+                uint saBatchN=0;
+                while (iChunkBatchNext<saChunkN && (saBatchN==0 || saBatchN+indPrefChunkCount[iChunkBatchNext]<=saChunkBatchSize)) {
+                    saBatchN += indPrefChunkCount[iChunkBatchNext];
+                    iChunkBatchNext++;
+                };
+                saChunkBatchN++;
+                iChunkBatch=iChunkBatchNext;
+            };
+        };
+
+        // Batched fill trades one genome scan per chunk for two scans per batch.
+        // It pays off once enough chunks are being sorted in parallel.
+        const bool saChunkBatchFill=P.runThreadN>=16 && saChunkN>1;
+        const uint64 saRetainedChunkBytes=nSA*sizeof(uint);
+        const uint64 saRamPackPeakBytes=saRetainedChunkBytes+SApass1.lengthByte;
+        const uint64 saRamPeakBytes=max(saAllChunkScatterBytes,saRamPackPeakBytes);
+        const uint64 saRamHeadroomBytes=max(saRamPeakBytes/10,(uint64) 2000000000LLU);
+        const uint64 saRamRequiredBytes=saRamPeakBytes+saRamHeadroomBytes;
+        const uint64 systemAvailableBytes=systemAvailableMemoryBytes();
+        const bool saRamLimitOK=saAvailableBytes>=saRamRequiredBytes;
+        const bool saRamSystemOK=systemAvailableBytes>0 && systemAvailableBytes>=saRamRequiredBytes;
+        bool saChunksInMemoryActive=saRamLimitOK && saRamSystemOK;
+        P.inOut->logMain  << "SA chunk all-scatter available bytes: " << saAvailableBytes << "; required temporary bytes: " << saAllChunkScatterBytes << "\n" <<flush;
+        P.inOut->logMain  << "SA chunk estimated batched-fill batches: " << saChunkBatchN << "\n" <<flush;
+        P.inOut->logMain  << "SA chunk fill strategy: " << (saChunkBatchFill ? "batched" : "per-chunk") << "\n" <<flush;
+        P.inOut->logMain  << "SA chunk sort prefix length: " << indPrefLen << "\n" <<flush;
+        P.inOut->logMain  << "SA chunk sort granularity: " << (saChunkBatchFill ? "prefix-bin" : "chunk") << "\n" <<flush;
+        P.inOut->logMain  << "SA chunk retained bytes: " << saRetainedChunkBytes << "; RAM peak bytes: " << saRamPeakBytes << "; RAM headroom bytes: " << saRamHeadroomBytes << "\n" <<flush;
+        P.inOut->logMain  << "SA chunk system available bytes: " << systemAvailableBytes << "; limit available bytes: " << saAvailableBytes << "\n" <<flush;
+        if (saSortProfile) {
+            uint saChunkMinCount=indPrefChunkCount[0];
+            uint saChunkMaxCount=indPrefChunkCount[0];
+            uint saChunkMaxIndex=0;
+            for (uint iChunk=1; iChunk<saChunkN; iChunk++) {
+                if (indPrefChunkCount[iChunk]<saChunkMinCount) {
+                    saChunkMinCount=indPrefChunkCount[iChunk];
+                };
+                if (indPrefChunkCount[iChunk]>saChunkMaxCount) {
+                    saChunkMaxCount=indPrefChunkCount[iChunk];
+                    saChunkMaxIndex=iChunk;
                 };
             };
+            P.inOut->logMain << "SA sort profile: enabled\n" <<flush;
+            P.inOut->logMain << "SA sort profile prefix bins: total=" << indPrefN
+                              << "; empty=" << indPrefEmptyN
+                              << "; nonempty=" << indPrefNonEmptyN
+                              << "; singleton=" << indPrefSingletonN
+                              << "; sortable=" << indPrefSortableN
+                              << "; max_bin=" << indPrefMaxCount
+                              << "; max_prefix=" << indPrefMaxIndex << "\n" <<flush;
+            P.inOut->logMain << "SA sort profile chunks: count=" << saChunkN
+                              << "; min_indices=" << saChunkMinCount
+                              << "; max_indices=" << saChunkMaxCount
+                              << "; max_chunk=" << saChunkMaxIndex
+                              << "; mean_indices=" << (saChunkN>0 ? nSA/saChunkN : 0) << "\n" <<flush;
+        };
 
-
-            //sort the chunk
-            qsort(saChunk,indPrefChunkCount[iChunk],sizeof(saChunk[0]),funCompareSuffixes);
-            for (uint ii=0;ii<indPrefChunkCount[iChunk];ii++) {
-                saChunk[ii]=2*nGenome-1-saChunk[ii];
+        uint* saChunksInMemory=NULL;
+        if (saChunksInMemoryActive) {
+            saChunksInMemory=new (nothrow) uint [nSA];
+            if (saChunksInMemory==NULL) {
+                saChunksInMemoryActive=false;
+                P.inOut->logMain << "SA chunk storage fallback: disk-backed after RAM allocation failure\n" <<flush;
             };
-            //write files
-            string chunkFileName=pGe.gDir+"/SA_"+to_string( (uint) iChunk);
-            ofstream & saChunkFile = ofstrOpen(chunkFileName,ERROR_OUT, P);
-            fstreamWriteBig(saChunkFile, (char*) saChunk, sizeof(saChunk[0])*indPrefChunkCount[iChunk],chunkFileName,ERROR_OUT,P);
-            saChunkFile.close();
-            delete [] saChunk;
-            saChunk=NULL;
+        };
+        P.inOut->logMain  << "SA chunk storage strategy: " << (saChunksInMemoryActive ? "RAM-retained" : "disk-backed") << "\n" <<flush;
+
+        double saProfileFillCountSeconds=0.0;
+        double saProfileFillScatterSeconds=0.0;
+        double saProfileSortSeconds=0.0;
+        double saProfileFinalizeSeconds=0.0;
+        uint saProfileSkipFirstWordRangeN=0;
+        uint saProfileSkipFirstWordIndexN=0;
+        uint saProfileSubBinPrefixN=0;
+        uint saProfileSubBinRangeN=0;
+        uint saProfileSubBinIndexN=0;
+
+        if (saChunkBatchFill) {
+            uint iChunkBatch=0;
+            while (iChunkBatch<saChunkN) {//fill a batch of chunks with two genome scans, then sort and write each chunk
+                uint iChunkBatchNext=iChunkBatch;
+                uint saBatchN=0;
+                while (iChunkBatchNext<saChunkN && (saBatchN==0 || saBatchN+indPrefChunkCount[iChunkBatchNext]<=saChunkBatchSize)) {
+                    saBatchN += indPrefChunkCount[iChunkBatchNext];
+                    iChunkBatchNext++;
+                };
+                uint batchChunkN=iChunkBatchNext-iChunkBatch;
+                uint* saBatch=saChunksInMemoryActive ? saChunksInMemory+saChunkStart[iChunkBatch] : new uint [saBatchN];
+                uint* saBatchStart=new uint [batchChunkN+1];
+                saBatchStart[0]=0;
+                for (uint iChunk=0;iChunk<batchChunkN;iChunk++) {
+                    saBatchStart[iChunk+1]=saBatchStart[iChunk]+indPrefChunkCount[iChunkBatch+iChunk];
+                };
+
+                uint batchPrefStart=indPrefStart[iChunkBatch];
+                uint batchPrefEnd=min(indPrefStart[iChunkBatchNext],indPrefN);
+                uint batchPrefN=batchPrefEnd-batchPrefStart;
+
+                uint* saPrefStart=new uint [batchPrefN+1];
+                saPrefStart[0]=0;
+                for (uint iPref=0;iPref<batchPrefN;iPref++) {
+                    saPrefStart[iPref+1]=saPrefStart[iPref]+indPrefCount[batchPrefStart+iPref];
+                };
+                if (saPrefStart[batchPrefN]!=saBatchN) {
+                    ostringstream errOut;
+                    errOut << "EXITING because of FATAL problem while generating the suffix array\n";
+                    errOut << "The number of indices collected for suffix array batch " << iChunkBatch;
+                    errOut << " = " << saPrefStart[batchPrefN] << " is not equal to expected " << saBatchN << "\n";
+                    errOut << "SOLUTION: try to re-run suffix array generation, if it still does not work, report this problem to the author\n"<<flush;
+                    exitWithError(errOut.str(),std::cerr, P.inOut->logMain, EXIT_CODE_INPUT_FILES, P);
+                };
+
+                uint* saThreadPrefCount=new uint [(uint) P.runThreadN*batchPrefN];
+                memset(saThreadPrefCount,0,sizeof(saThreadPrefCount[0])*(uint) P.runThreadN*batchPrefN);
+
+                double saProfileTime0=omp_get_wtime();
+                #pragma omp parallel num_threads(P.runThreadN)
+                {
+                    int tid=omp_get_thread_num();
+                    uint* threadPrefCount=saThreadPrefCount+(uint) tid*batchPrefN;
+                    #pragma omp for schedule(static)
+                    for (uint iScan=0;iScan<genomeScanN;iScan++) {
+                        uint ii=iScan*pGe.gSAsparseD;
+                        if (G[ii]<4) {
+                            uint p1=funSAsortPrefix(G,ii,indPrefLen);
+                            if (p1>=batchPrefStart && p1<batchPrefEnd) {
+                                threadPrefCount[p1-batchPrefStart]++;
+                            };
+                        };
+                    };
+                };
+                if (saSortProfile) {
+                    saProfileFillCountSeconds += omp_get_wtime()-saProfileTime0;
+                };
+
+                uint* saThreadPrefStart=new uint [(uint) P.runThreadN*batchPrefN];
+                for (uint iPref=0;iPref<batchPrefN;iPref++) {
+                    uint prefCount=0;
+                    for (int iThread=0;iThread<P.runThreadN;iThread++) {
+                        saThreadPrefStart[(uint) iThread*batchPrefN+iPref]=saPrefStart[iPref]+prefCount;
+                        prefCount += saThreadPrefCount[(uint) iThread*batchPrefN+iPref];
+                    };
+                    if (prefCount!=indPrefCount[batchPrefStart+iPref]) {
+                        ostringstream errOut;
+                        errOut << "EXITING because of FATAL problem while generating the suffix array\n";
+                        errOut << "The number of indices collected for suffix array prefix " << batchPrefStart+iPref << " = " << prefCount;
+                        errOut << " is not equal to expected " << indPrefCount[batchPrefStart+iPref] << "\n";
+                        errOut << "SOLUTION: try to re-run suffix array generation, if it still does not work, report this problem to the author\n"<<flush;
+                        exitWithError(errOut.str(),std::cerr, P.inOut->logMain, EXIT_CODE_INPUT_FILES, P);
+                    };
+                };
+
+                saProfileTime0=omp_get_wtime();
+                #pragma omp parallel num_threads(P.runThreadN)
+                {
+                    int tid=omp_get_thread_num();
+                    uint* threadPrefStart=saThreadPrefStart+(uint) tid*batchPrefN;
+                    #pragma omp for schedule(static)
+                    for (uint iScan=0;iScan<genomeScanN;iScan++) {
+                        uint ii=iScan*pGe.gSAsparseD;
+                        if (G[ii]<4) {
+                            uint p1=funSAsortPrefix(G,ii,indPrefLen);
+                            if (p1>=batchPrefStart && p1<batchPrefEnd) {
+                                uint iPref=p1-batchPrefStart;
+                                saBatch[threadPrefStart[iPref]]=ii;
+                                threadPrefStart[iPref]++;
+                            };
+                        };
+                    };
+                };
+                if (saSortProfile) {
+                    saProfileFillScatterSeconds += omp_get_wtime()-saProfileTime0;
+                };
+
+                saProfileTime0=omp_get_wtime();
+                const bool saCanSkipFirstWord=indPrefLen>=(uint) sizeof(uint) && globalL>1;
+                const uint saSubBinExtraLen=3;
+                const uint saSubBinN=216; // 6^3
+                const uint saSubBinMinN=1000000;
+                vector<uint*> saSortRange;
+                vector<uint> saSortRangeN;
+                vector<char> saSortRangeSkipFirstWord;
+                saSortRange.reserve(batchPrefN);
+                saSortRangeN.reserve(batchPrefN);
+                saSortRangeSkipFirstWord.reserve(batchPrefN);
+                for (uint iPref=0; iPref < batchPrefN; iPref++) {
+                    uint* saPref=saBatch+saPrefStart[iPref];
+                    uint saPrefN=saPrefStart[iPref+1]-saPrefStart[iPref];
+                    if (saPrefN>1) {
+                        bool skipFirstWord=saCanSkipFirstWord && !funSAsortPrefixFirstWordHas5(batchPrefStart+iPref,indPrefLen);
+                        bool subBinned=false;
+                        if (skipFirstWord && saPrefN>=saSubBinMinN) {
+                            uint saSubBinCount[saSubBinN];
+                            memset(saSubBinCount,0,sizeof(saSubBinCount));
+                            bool subBinOK=true;
+                            for (uint ii=0; ii<saPrefN; ii++) {
+                                if (saPref[ii]<indPrefLen+saSubBinExtraLen-1) {
+                                    subBinOK=false;
+                                    break;
+                                };
+                                saSubBinCount[funSAsortPrefixAtOffset(G,saPref[ii],indPrefLen,saSubBinExtraLen)]++;
+                            };
+
+                            uint saSubBinNonEmptyN=0;
+                            uint saSubBinStart[saSubBinN+1];
+                            saSubBinStart[0]=0;
+                            if (subBinOK) {
+                                for (uint ii=0; ii<saSubBinN; ii++) {
+                                    if (saSubBinCount[ii]>0) {
+                                        saSubBinNonEmptyN++;
+                                    };
+                                    saSubBinStart[ii+1]=saSubBinStart[ii]+saSubBinCount[ii];
+                                };
+                            };
+
+                            uint* saPrefTmp=NULL;
+                            if (saSubBinNonEmptyN>1) {
+                                saPrefTmp=new (nothrow) uint [saPrefN];
+                            };
+                            if (saPrefTmp!=NULL) {
+                                uint saSubBinCursor[saSubBinN];
+                                memcpy(saSubBinCursor,saSubBinStart,sizeof(saSubBinCursor));
+                                for (uint ii=0; ii<saPrefN; ii++) {
+                                    uint iSub=funSAsortPrefixAtOffset(G,saPref[ii],indPrefLen,saSubBinExtraLen);
+                                    saPrefTmp[saSubBinCursor[iSub]]=saPref[ii];
+                                    saSubBinCursor[iSub]++;
+                                };
+                                memcpy(saPref,saPrefTmp,saPrefN*sizeof(saPref[0]));
+                                delete [] saPrefTmp;
+
+                                uint saSubBinSortRangeN=0;
+                                for (uint iSub=0; iSub<saSubBinN; iSub++) {
+                                    uint saSubN=saSubBinStart[iSub+1]-saSubBinStart[iSub];
+                                    if (saSubN>1) {
+                                        saSortRange.push_back(saPref+saSubBinStart[iSub]);
+                                        saSortRangeN.push_back(saSubN);
+                                        saSortRangeSkipFirstWord.push_back(1);
+                                        saSubBinSortRangeN++;
+                                    };
+                                };
+                                if (saSortProfile) {
+                                    saProfileSubBinPrefixN++;
+                                    saProfileSubBinRangeN += saSubBinSortRangeN;
+                                    saProfileSubBinIndexN += saPrefN;
+                                };
+                                subBinned=true;
+                            };
+                        };
+                        if (!subBinned) {
+                            saSortRange.push_back(saPref);
+                            saSortRangeN.push_back(saPrefN);
+                            saSortRangeSkipFirstWord.push_back(skipFirstWord ? 1 : 0);
+                        };
+                    };
+                };
+
+                #pragma omp parallel for num_threads(P.runThreadN) schedule(dynamic,16) reduction(+:saProfileSkipFirstWordRangeN,saProfileSkipFirstWordIndexN)
+                for (int iRange=0; iRange < (int) saSortRangeN.size(); iRange++) {
+                    uint* saRange=saSortRange[iRange];
+                    uint saRangeN=saSortRangeN[iRange];
+                    if (saSortRangeSkipFirstWord[iRange]) {
+                        qsort(saRange,saRangeN,sizeof(saRange[0]),funCompareSuffixesSkipFirstWord);
+                        if (saSortProfile) {
+                            saProfileSkipFirstWordRangeN++;
+                            saProfileSkipFirstWordIndexN += saRangeN;
+                        };
+                    } else {
+                        qsort(saRange,saRangeN,sizeof(saRange[0]),funCompareSuffixes);
+                    };
+                };
+                if (saSortProfile) {
+                    saProfileSortSeconds += omp_get_wtime()-saProfileTime0;
+                };
+
+                saProfileTime0=omp_get_wtime();
+                #pragma omp parallel for num_threads(P.runThreadN) schedule(dynamic,1)
+                for (int iChunk=0; iChunk < (int) batchChunkN; iChunk++) {
+                    uint iChunkAbs=iChunkBatch+(uint) iChunk;
+                    uint* saChunk=saBatch+saBatchStart[iChunk];
+                    for (uint ii=0;ii<indPrefChunkCount[iChunkAbs];ii++) {
+                        saChunk[ii]=2*nGenome-1-saChunk[ii];
+                    };
+                    if (!saChunksInMemoryActive) {
+                        string chunkFileName=pGe.gDir+"/SA_"+to_string(iChunkAbs);
+                        ofstream & saChunkFile = ofstrOpen(chunkFileName,ERROR_OUT, P);
+                        fstreamWriteBig(saChunkFile, (char*) saChunk, sizeof(saChunk[0])*indPrefChunkCount[iChunkAbs],chunkFileName,ERROR_OUT,P);
+                        saChunkFile.close();
+                    };
+                };
+                if (saSortProfile) {
+                    saProfileFinalizeSeconds += omp_get_wtime()-saProfileTime0;
+                };
+
+                delete [] saThreadPrefStart;
+                delete [] saThreadPrefCount;
+                delete [] saPrefStart;
+                delete [] saBatchStart;
+                if (!saChunksInMemoryActive) {
+                    delete [] saBatch;
+                };
+                iChunkBatch=iChunkBatchNext;
+            };
+        } else {
+            #pragma omp parallel for num_threads(P.runThreadN) schedule(dynamic,1) reduction(+:saProfileFillScatterSeconds,saProfileSortSeconds,saProfileFinalizeSeconds)
+            for (int iChunk=0; iChunk < (int) saChunkN; iChunk++) {//start the chunk cycle: sort each chunk with qsort and write to a file
+                uint* saChunk=saChunksInMemoryActive ? saChunksInMemory+saChunkStart[iChunk] : new uint [indPrefChunkCount[iChunk]];//allocate local array for each chunk
+                double saProfileTime0=omp_get_wtime();
+                for (uint ii=0,jj=0;ii<2*nGenome;ii+=pGe.gSAsparseD) {//fill the chunk with SA indices
+                    if (G[ii]<4) {
+                        uint p1=funSAsortPrefix(G,ii,indPrefLen);
+                        if (p1>=indPrefStart[iChunk] && p1<indPrefStart[iChunk+1]) {
+                            saChunk[jj]=ii;
+                            jj++;
+                            if (jj==indPrefChunkCount[iChunk]) break;
+                        };
+                    };
+                };
+                if (saSortProfile) {
+                    saProfileFillScatterSeconds += omp_get_wtime()-saProfileTime0;
+                };
+
+                //sort the chunk
+                saProfileTime0=omp_get_wtime();
+                if (indPrefChunkCount[iChunk]>1) {
+                    qsort(saChunk,indPrefChunkCount[iChunk],sizeof(saChunk[0]),funCompareSuffixes);
+                };
+                if (saSortProfile) {
+                    saProfileSortSeconds += omp_get_wtime()-saProfileTime0;
+                };
+                saProfileTime0=omp_get_wtime();
+                for (uint ii=0;ii<indPrefChunkCount[iChunk];ii++) {
+                    saChunk[ii]=2*nGenome-1-saChunk[ii];
+                };
+                //write files
+                if (!saChunksInMemoryActive) {
+                    string chunkFileName=pGe.gDir+"/SA_"+to_string( (uint) iChunk);
+                    ofstream & saChunkFile = ofstrOpen(chunkFileName,ERROR_OUT, P);
+                    fstreamWriteBig(saChunkFile, (char*) saChunk, sizeof(saChunk[0])*indPrefChunkCount[iChunk],chunkFileName,ERROR_OUT,P);
+                    saChunkFile.close();
+                    delete [] saChunk;
+                    saChunk=NULL;
+                };
+                if (saSortProfile) {
+                    saProfileFinalizeSeconds += omp_get_wtime()-saProfileTime0;
+                };
+            };
+        };
+
+        if (saSortProfile) {
+            ostringstream saProfileOut;
+            saProfileOut << fixed << setprecision(3);
+            saProfileOut << "SA sort profile phases: fill_count_seconds=" << saProfileFillCountSeconds
+                         << "; fill_scatter_seconds=" << saProfileFillScatterSeconds
+                         << "; sort_seconds=" << saProfileSortSeconds
+                         << "; finalize_seconds=" << saProfileFinalizeSeconds;
+            P.inOut->logMain << saProfileOut.str() << "\n" <<flush;
+            P.inOut->logMain << "SA sort profile comparator: skip_first_word_ranges=" << saProfileSkipFirstWordRangeN
+                              << "; skip_first_word_indices=" << saProfileSkipFirstWordIndexN << "\n" <<flush;
+            P.inOut->logMain << "SA sort profile sub-bins: prefixes=" << saProfileSubBinPrefixN
+                              << "; ranges=" << saProfileSubBinRangeN
+                              << "; indices=" << saProfileSubBinIndexN << "\n" <<flush;
         };
 
         time ( &rawTime );
-        P.inOut->logMain     << timeMonthDayTime(rawTime) <<" ... loading chunks from disk, packing SA...\n" <<flush;
-        *P.inOut->logStdOut  << timeMonthDayTime(rawTime) <<" ... loading chunks from disk, packing SA...\n" <<flush;
+        P.inOut->logMain     << timeMonthDayTime(rawTime) << (saChunksInMemoryActive ? " ... packing SA from RAM chunks...\n" : " ... loading chunks from disk, packing SA...\n") <<flush;
+        *P.inOut->logStdOut  << timeMonthDayTime(rawTime) << (saChunksInMemoryActive ? " ... packing SA from RAM chunks...\n" : " ... loading chunks from disk, packing SA...\n") <<flush;
 
         //read chunks and pack into full SA
         SApass1.allocateArray();
@@ -299,36 +748,49 @@ void Genome::genomeGenerate() {
         uint N2bit= 1LLU << GstrandBit;
         uint packedInd=0;
 
-        #define SA_CHUNK_BLOCK_SIZE 10000000
-        uint* saIn=new uint[SA_CHUNK_BLOCK_SIZE]; //TODO make adjustable
-
         #ifdef genenomeGenerate_SA_textOutput
                 ofstream SAtxtStream ((pGe.gDir + "/SAtxt").c_str());
         #endif
 
-        for (uint iChunk=0;iChunk<saChunkN;iChunk++) {//load files one by one and convert to packed
-            ostringstream saChunkFileNameStream("");
-            saChunkFileNameStream<< pGe.gDir << "/SA_" << iChunk;
-            ifstream saChunkFile(saChunkFileNameStream.str().c_str());
-            while (! saChunkFile.eof()) {//read blocks from each file
-                uint chunkBytesN=fstreamReadBig(saChunkFile,(char*) saIn,SA_CHUNK_BLOCK_SIZE*sizeof(saIn[0]));
-                for (uint ii=0;ii<chunkBytesN/sizeof(saIn[0]);ii++) {
-                    SA.writePacked( packedInd+ii, (saIn[ii]<nGenome) ? saIn[ii] : ( (saIn[ii]-nGenome) | N2bit ) );
+        if (saChunksInMemoryActive) {
+            for (uint ii=0; ii<nSA; ii++) {
+                SA.writePacked( ii, (saChunksInMemory[ii]<nGenome) ? saChunksInMemory[ii] : ( (saChunksInMemory[ii]-nGenome) | N2bit ) );
 
-                    #ifdef genenomeGenerate_SA_textOutput
-                        SAtxtStream << saIn[ii] << "\n";
-                    #endif
-                };
-                packedInd += chunkBytesN/sizeof(saIn[0]);
+                #ifdef genenomeGenerate_SA_textOutput
+                    SAtxtStream << saChunksInMemory[ii] << "\n";
+                #endif
             };
-            saChunkFile.close();
-            remove(saChunkFileNameStream.str().c_str());//remove the chunk file
+            packedInd=nSA;
+            delete [] saChunksInMemory;
+            saChunksInMemory=NULL;
+        } else {
+            #define SA_CHUNK_BLOCK_SIZE 10000000
+            uint* saIn=new uint[SA_CHUNK_BLOCK_SIZE]; //TODO make adjustable
+
+            for (uint iChunk=0;iChunk<saChunkN;iChunk++) {//load files one by one and convert to packed
+                ostringstream saChunkFileNameStream("");
+                saChunkFileNameStream<< pGe.gDir << "/SA_" << iChunk;
+                ifstream saChunkFile(saChunkFileNameStream.str().c_str());
+                while (! saChunkFile.eof()) {//read blocks from each file
+                    uint chunkBytesN=fstreamReadBig(saChunkFile,(char*) saIn,SA_CHUNK_BLOCK_SIZE*sizeof(saIn[0]));
+                    for (uint ii=0;ii<chunkBytesN/sizeof(saIn[0]);ii++) {
+                        SA.writePacked( packedInd+ii, (saIn[ii]<nGenome) ? saIn[ii] : ( (saIn[ii]-nGenome) | N2bit ) );
+
+                        #ifdef genenomeGenerate_SA_textOutput
+                            SAtxtStream << saIn[ii] << "\n";
+                        #endif
+                    };
+                    packedInd += chunkBytesN/sizeof(saIn[0]);
+                };
+                saChunkFile.close();
+                remove(saChunkFileNameStream.str().c_str());//remove the chunk file
+            };
+            delete [] saIn;
         };
 
         #ifdef genenomeGenerate_SA_textOutput
                 SAtxtStream.close();
         #endif
-        delete [] saIn;
 
         if (packedInd != nSA ) {//
             ostringstream errOut;
@@ -346,6 +808,7 @@ void Genome::genomeGenerate() {
         delete [] indPrefCount;
         delete [] indPrefStart;
         delete [] indPrefChunkCount;
+        delete [] saChunkStart;
     };
 
     time ( &rawTime );

--- a/source/genomeSAindex.cpp
+++ b/source/genomeSAindex.cpp
@@ -3,6 +3,93 @@
 #include "SuffixArrayFuns.h"
 #include "ErrorWarning.h"
 
+struct SAindexEvent {
+    uint isa;
+    uint indFull;
+    int iL4;
+};
+
+static bool SAindexEventEqual(uint indFull1, int iL41, uint indFull2, int iL42)
+{
+    return indFull1==indFull2 && iL41==iL42;
+};
+
+static void SAindexProcessEvent(PackedArray &SAi, Genome &mapGen, uint isa, uint indFull, int iL4, uint* ind0)
+{
+    for (uint iL=0; iL < mapGen.pGe.gSAindexNbases; iL++) {//calculate index
+
+        uint indPref = indFull >> (2*(mapGen.pGe.gSAindexNbases-1-iL));
+
+        if ( (int)iL==iL4 ) {//this suffix contains N and does not belong in SAi
+            for (uint iL1=iL; iL1 < mapGen.pGe.gSAindexNbases; iL1++) {
+                SAi.writePacked(mapGen.genomeSAindexStart[iL1]+ind0[iL1],SAi[mapGen.genomeSAindexStart[iL1]+ind0[iL1]] | mapGen.SAiMarkNmaskC);
+            };
+            break;//break the iL cycle
+        };
+
+        if ( indPref > ind0[iL] || isa==0 ) {//new && good index, record it
+
+            SAi.writePacked(mapGen.genomeSAindexStart[iL]+indPref, isa);
+
+            for (uint ii=ind0[iL]+1; ii<indPref; ii++) {//index is not present, record to the last present suffix
+                SAi.writePacked(mapGen.genomeSAindexStart[iL]+ii, isa | mapGen.SAiMarkAbsentMaskC);
+            };
+            ind0[iL]=indPref;
+
+        } else if ( indPref < ind0[iL] ) {
+            ostringstream errOut;
+            errOut << "BUG: next index is smaller than previous, EXITING\n" <<flush;
+            exitWithError(errOut.str(),std::cerr, mapGen.P.inOut->logMain, EXIT_CODE_INPUT_FILES, mapGen.P);
+        };
+    };
+};
+
+static void SAindexScanEventsParallel(char *G, PackedArray &SA, Parameters &P, Genome &mapGen, uint iSA1, uint iSA2, vector<SAindexEvent> &events)
+{
+    const uint nSA=iSA2-iSA1+1;
+    const uint chunkN=min<uint>(nSA, max<uint>(1, P.runThreadN*4));
+    const int threadN=(int) min<uint>(P.runThreadN, chunkN);
+    vector<vector<SAindexEvent> > eventsByChunk(chunkN);
+
+    #pragma omp parallel for num_threads(threadN) schedule(static)
+    for (uint iChunk=0; iChunk<chunkN; iChunk++) {
+        const uint iStart=iSA1 + nSA*iChunk/chunkN;
+        const uint iEnd=iSA1 + nSA*(iChunk+1)/chunkN;
+
+        vector<SAindexEvent> &chunkEvents=eventsByChunk[iChunk];
+        chunkEvents.reserve((iEnd-iStart)/32+1);
+
+        int iL4prev=-1;
+        uint indFullPrev=0;
+        if (iStart>iSA1) {
+            indFullPrev=funCalcSAiFromSA(G,SA,mapGen,iStart-1,mapGen.pGe.gSAindexNbases,iL4prev);
+        };
+
+        for (uint isa=iStart; isa<iEnd; isa++) {
+            int iL4=0;
+            uint indFull=funCalcSAiFromSA(G,SA,mapGen,isa,mapGen.pGe.gSAindexNbases,iL4);
+            if (isa==iSA1 || !SAindexEventEqual(indFull, iL4, indFullPrev, iL4prev)) {
+                SAindexEvent event;
+                event.isa=isa;
+                event.indFull=indFull;
+                event.iL4=iL4;
+                chunkEvents.push_back(event);
+            };
+            indFullPrev=indFull;
+            iL4prev=iL4;
+        };
+    };
+
+    uint eventN=0;
+    for (uint iChunk=0; iChunk<chunkN; iChunk++) {
+        eventN += eventsByChunk[iChunk].size();
+    };
+    events.reserve(eventN);
+    for (uint iChunk=0; iChunk<chunkN; iChunk++) {
+        events.insert(events.end(), eventsByChunk[iChunk].begin(), eventsByChunk[iChunk].end());
+    };
+};
+
 void genomeSAindex(char * G, PackedArray & SA, Parameters & P, PackedArray & SAi, Genome &mapGen)
  {
     mapGen.genomeSAindexStart = new uint [mapGen.pGe.gSAindexNbases+1];
@@ -116,54 +203,39 @@ void genomeSAindex(char * G, PackedArray & SA, Parameters & P, PackedArray & SAi
 
 void genomeSAindexChunk(char * G, PackedArray & SA, Parameters & P, PackedArray & SAi, uint iSA1, uint iSA2, Genome &mapGen)
 {
+    const bool parallelEvents=P.runThreadN>=16 && iSA1==0 && iSA2+1==mapGen.nSA;
+
+    P.inOut->logMain << "SAindex traversal strategy: " << (parallelEvents ? "parallel-events" : "skip-search") << "\n" << flush;
+
     uint* ind0=new uint[mapGen.pGe.gSAindexNbases];
 
     for (uint ii=0; ii<mapGen.pGe.gSAindexNbases; ii++) {
         ind0[ii]=-1;//this is needed in case "AAA...AAA",i.e. indPref=0 is not present in the genome for some lengths
     };
 
-    PackedArray SAi1;
-    SAi1=SAi;
-    SAi1.allocateArray();
+    if (parallelEvents) {
+        vector<SAindexEvent> events;
+        SAindexScanEventsParallel(G, SA, P, mapGen, iSA1, iSA2, events);
 
-    uint isaStep=mapGen.nSA/(1llu<<(2*mapGen.pGe.gSAindexNbases))+1;
+        P.inOut->logMain << "SAindex event count: " << events.size() << "\n" << flush;
+        for (uint iEvent=0; iEvent<events.size(); iEvent++) {
+            SAindexProcessEvent(SAi, mapGen, events[iEvent].isa, events[iEvent].indFull, events[iEvent].iL4, ind0);
+        };
+    } else {
+        uint isaStep=mapGen.nSA/(1llu<<(2*mapGen.pGe.gSAindexNbases))+1;
 //     isaStep=8;
 
-    uint isa=iSA1;
-    int iL4;
-    uint indFull=funCalcSAiFromSA(G,SA,mapGen,isa,mapGen.pGe.gSAindexNbases,iL4);
-    while (isa<=iSA2) {//for all suffixes
-        for (uint iL=0; iL < mapGen.pGe.gSAindexNbases; iL++) {//calculate index
+        uint isa=iSA1;
+        int iL4;
+        uint indFull=funCalcSAiFromSA(G,SA,mapGen,isa,mapGen.pGe.gSAindexNbases,iL4);
+        while (isa<=iSA2) {//for all suffixes
+            SAindexProcessEvent(SAi, mapGen, isa, indFull, iL4, ind0);
 
-            uint indPref = indFull >> (2*(mapGen.pGe.gSAindexNbases-1-iL));
+            //find next index not equal to the current one
+            funSAiFindNextIndex(G, SA, isaStep, isa, indFull, iL4, mapGen);//indFull and iL4 have been already defined at the previous step
 
-            if ( (int)iL==iL4 ) {//this suffix contains N and does not belong in SAi
-                for (uint iL1=iL; iL1 < mapGen.pGe.gSAindexNbases; iL1++) {
-                    SAi.writePacked(mapGen.genomeSAindexStart[iL1]+ind0[iL1],SAi[mapGen.genomeSAindexStart[iL1]+ind0[iL1]] | mapGen.SAiMarkNmaskC);
-                };
-                break;//break the iL cycle
-            };
-
-            if ( indPref > ind0[iL] || isa==0 ) {//new && good index, record it
-
-                SAi.writePacked(mapGen.genomeSAindexStart[iL]+indPref, isa);
-
-                for (uint ii=ind0[iL]+1; ii<indPref; ii++) {//index is not present, record to the last present suffix
-                    SAi.writePacked(mapGen.genomeSAindexStart[iL]+ii, isa | mapGen.SAiMarkAbsentMaskC);
-                };
-                ind0[iL]=indPref;
-
-            } else if ( indPref < ind0[iL] ) {
-                ostringstream errOut;
-                errOut << "BUG: next index is smaller than previous, EXITING\n" <<flush;
-                exitWithError(errOut.str(),std::cerr, P.inOut->logMain, EXIT_CODE_INPUT_FILES, P);
-            };
-        };
-
-        //find next index not equal to the current one
-        funSAiFindNextIndex(G, SA, isaStep, isa, indFull, iL4, mapGen);//indFull and iL4 have been already defined at the previous step
-
-    };//isa cycle
+        };//isa cycle
+    };
 
     for (uint iL=0; iL < mapGen.pGe.gSAindexNbases; iL++) {//fill up unfilled indexes
     	for (uint ii=mapGen.genomeSAindexStart[iL]+ind0[iL]+1; ii<mapGen.genomeSAindexStart[iL+1]; ii++) {

--- a/source/sjdbBuildIndex.cpp
+++ b/source/sjdbBuildIndex.cpp
@@ -13,6 +13,96 @@
 
 #include "funCompareUintAndSuffixes.h"
 
+static uint sjdbSortBucket(uint64 key, uint64 keyRange, uint bucketN)
+{
+    uint bucket=(uint) (((uint128) key*bucketN)/keyRange);
+    return bucket<bucketN ? bucket : bucketN-1;
+};
+
+static bool sjdbSortIndicesParallel(Parameters &P, uint64* indArray, uint nInd, uint64 keyRange, char* Gsj)
+{
+    g_funCompareUintAndSuffixes_G=Gsj;
+
+    if (P.runThreadN<4 || nInd<1000000 || keyRange==0) {
+        qsort((void*) indArray, nInd, 2*sizeof(uint64), funCompareUintAndSuffixes);
+        return false;
+    };
+
+    uint bucketN=1;
+    while (bucketN<(uint) P.runThreadN*64 && bucketN<16384) {
+        bucketN <<= 1;
+    };
+    if (bucketN>nInd) {
+        bucketN=1;
+        while ((bucketN<<1)<=nInd) bucketN <<= 1;
+    };
+    if (bucketN<2) {
+        qsort((void*) indArray, nInd, 2*sizeof(uint64), funCompareUintAndSuffixes);
+        return false;
+    };
+
+    const uint64 indBytes=2*nInd*sizeof(uint64);
+    const uint64 auxBytes=indBytes + (uint64) P.runThreadN*bucketN*2*sizeof(uint64) + (bucketN+1)*sizeof(uint64);
+    if (P.limitGenomeGenerateRAM>0 && auxBytes>P.limitGenomeGenerateRAM/4) {
+        qsort((void*) indArray, nInd, 2*sizeof(uint64), funCompareUintAndSuffixes);
+        return false;
+    };
+
+    vector<uint64> bucketCount((uint) P.runThreadN*bucketN,0);
+    #pragma omp parallel num_threads(P.runThreadN)
+    {
+        uint tid=(uint) omp_get_thread_num();
+        uint64* threadBucketCount=bucketCount.data()+tid*bucketN;
+        #pragma omp for schedule(static)
+        for (uint ii=0; ii<nInd; ii++) {
+            ++threadBucketCount[sjdbSortBucket(indArray[2*ii],keyRange,bucketN)];
+        };
+    };
+
+    vector<uint64> bucketStart(bucketN+1,0);
+    for (uint iBucket=0; iBucket<bucketN; iBucket++) {
+        uint64 bucketTotal=0;
+        for (int iThread=0; iThread<P.runThreadN; iThread++) {
+            bucketTotal += bucketCount[(uint) iThread*bucketN+iBucket];
+        };
+        bucketStart[iBucket+1]=bucketStart[iBucket]+bucketTotal;
+    };
+
+    vector<uint64> bucketThreadStart((uint) P.runThreadN*bucketN,0);
+    for (uint iBucket=0; iBucket<bucketN; iBucket++) {
+        uint64 offset=bucketStart[iBucket];
+        for (int iThread=0; iThread<P.runThreadN; iThread++) {
+            bucketThreadStart[(uint) iThread*bucketN+iBucket]=offset;
+            offset += bucketCount[(uint) iThread*bucketN+iBucket];
+        };
+    };
+
+    uint64* indArray1=new uint64[2*nInd+2];
+    #pragma omp parallel num_threads(P.runThreadN)
+    {
+        uint tid=(uint) omp_get_thread_num();
+        uint64* threadBucketStart=bucketThreadStart.data()+tid*bucketN;
+        #pragma omp for schedule(static)
+        for (uint ii=0; ii<nInd; ii++) {
+            uint iBucket=sjdbSortBucket(indArray[2*ii],keyRange,bucketN);
+            uint64 jj=threadBucketStart[iBucket]++;
+            indArray1[2*jj]=indArray[2*ii];
+            indArray1[2*jj+1]=indArray[2*ii+1];
+        };
+    };
+
+    #pragma omp parallel for num_threads(P.runThreadN) schedule(dynamic,1)
+    for (int iBucket=0; iBucket<(int) bucketN; iBucket++) {
+        qsort((void*) (indArray1+2*bucketStart[(uint) iBucket]),
+              bucketStart[(uint) iBucket+1]-bucketStart[(uint) iBucket],
+              2*sizeof(uint64), funCompareUintAndSuffixes);
+    };
+
+    memcpy(indArray,indArray1,indBytes);
+    delete [] indArray1;
+    return true;
+};
+
 void sjdbBuildIndex (Parameters &P, char *Gsj, char *G, PackedArray &SA, PackedArray &SA2, PackedArray &SAi, Genome &mapGen, Genome &mapGen1) {
 
     #define SPACER_CHAR GENOME_spacingChar
@@ -98,10 +188,10 @@ void sjdbBuildIndex (Parameters &P, char *Gsj, char *G, PackedArray &SA, PackedA
         };
     };
 
-    g_funCompareUintAndSuffixes_G=Gsj;
-    qsort((void*) indArray, nInd, 2*sizeof(uint64), funCompareUintAndSuffixes);
+    bool parallelSort=sjdbSortIndicesParallel(P, indArray, nInd, mapGen1.nSA+1, Gsj);
     time ( &rawtime );
-    P.inOut->logMain  << timeMonthDayTime(rawtime) << "   Finished sorting SA indicesL nInd="<<nInd <<endl;
+    P.inOut->logMain  << timeMonthDayTime(rawtime) << "   Finished sorting SA indicesL nInd="<<nInd
+                       << " strategy=" << (parallelSort ? "parallel-bucket" : "qsort") <<endl;
 
     indArray[2*nInd]=-999; //mark the last junction
     indArray[2*nInd+1]=-999; //mark the last junction
@@ -259,30 +349,51 @@ void sjdbBuildIndex (Parameters &P, char *Gsj, char *G, PackedArray &SA, PackedA
 
     };
 
+    // Cache the first N/spacer position for each junction suffix. Most suffixes
+    // have no N in the SAindex prefix, so the SAi marking pass can skip them.
+    vector<uint8> sjdbFirstN(2*nGsj+1,mapGen.pGe.gSAindexNbases);
+    uint nextN=2*nGsj;
+    for (int64 ii=2*(int64)nGsj; ii>=0; ii--) {
+        if (Gsj[ii]>3) {
+            nextN=(uint) ii;
+        };
+        uint nDist=nextN-(uint) ii;
+        if (nDist<mapGen.pGe.gSAindexNbases) {
+            sjdbFirstN[ii]=(uint8) nDist;
+        };
+    };
+
+    uint64 sjdbSAiNmarkN=0;
     for (uint isj=0;isj<nInd;isj++) {
+        uint isjG=indArray[2*isj+1];
+        uint iL=sjdbFirstN[isjG];
+        if (iL>=mapGen.pGe.gSAindexNbases) {
+            continue;
+        };
+        sjdbSAiNmarkN++;
+
         int64 ind1=0;
-        for (uint iL=0; iL < mapGen.pGe.gSAindexNbases; iL++) {
-            uint g=(uint) Gsj[indArray[2*isj+1]+iL];
+        for (uint iL0=0; iL0<iL; iL0++) {
             ind1 <<= 2;
-            if (g>3) {//this iSA contains N, need to mark the previous
-                for (uint iL1=iL; iL1 < mapGen.pGe.gSAindexNbases; iL1++) {
-                    ind1+=3;
-                    int64 ind2=mapGen.genomeSAindexStart[iL1]+ind1;
-                    for (; ind2>=0; ind2--) {//find previous index that is not absent
-                        if ( (SAi[ind2] & mapGen.SAiMarkAbsentMaskC)==0 ) {
-                            break;
-                        };
-                    };
-                    SAi.writePacked(ind2,SAi[ind2] | mapGen.SAiMarkNmaskC);
-                    ind1 <<= 2;
+            ind1 += (uint) Gsj[isjG+iL0];
+        };
+
+        ind1 <<= 2;
+        for (uint iL1=iL; iL1 < mapGen.pGe.gSAindexNbases; iL1++) {
+            ind1+=3;
+            int64 ind2=mapGen.genomeSAindexStart[iL1]+ind1;
+            for (; ind2>=0; ind2--) {//find previous index that is not absent
+                if ( (SAi[ind2] & mapGen.SAiMarkAbsentMaskC)==0 ) {
+                    break;
                 };
-                break;
-            } else {
-                ind1 += g;
             };
+            SAi.writePacked(ind2,SAi[ind2] | mapGen.SAiMarkNmaskC);
+            ind1 <<= 2;
         };
     };
     time ( &rawtime );
+    P.inOut->logMain  << timeMonthDayTime(rawtime) << "   Finished SAi N marking: candidates=" << sjdbSAiNmarkN
+                       << " strategy=first-N-cache" <<endl;
     P.inOut->logMain  << timeMonthDayTime(rawtime) << "   Finished SAi" <<endl;
 
     //change parameters, most parameters are already re-defined in sjdbPrepare.cpp


### PR DESCRIPTION
## Summary
- improve `genomeGenerate` multi-core throughput for large references
- batch suffix-array chunk filling by prefix bin, retain sorted chunks in RAM when memory allows, and split very large prefix bins into ordered sub-bins before sorting
- parallelize SAindex traversal and junction-index work where output order can remain deterministic
- add `extras/tests/scripts/benchmarkGenomeGenerate.sh` to capture wall time, CPU/I/O samples, and genomeGenerate stage timings

## Benchmark notes
- Local full CHM13v2 + ERCC + GTF benchmark, 96 threads, `--genomeSAindexNbases 14`, `--genomeChrBinNbits 18`, `--limitGenomeGenerateRAM 300000000000`
- Baseline STAR 2.7.11b local run: 1164.89s
- Best local run from this branch: 653.76s
- Final pushed PR validation run: 685.29s in `results/full_chm13_prfinal_20260520`
- In the final validation run, suffix-array chunk sorting took 282s wall; profiled internals were `fill_count_seconds=1.629`, `fill_scatter_seconds=36.699`, `sort_seconds=237.783`, `finalize_seconds=1.788`
- Adaptive large-bin splitting sub-binned 116 large prefixes into 7427 sort ranges covering 194,932,600 suffixes
- Outputs were byte-identical for `Genome`, `SA`, `SAindex`, chromosome metadata, and `sjdbList.out.tab` against the prior accepted optimized build

## Validation
- `make -C source STAR`
- smoke `benchmarkGenomeGenerate.sh` runs at 1 and 16 threads
- full CHM13v2 + ERCC + GTF benchmark with `STAR_PROFILE_SA_SORT=1`
- byte comparisons for core generated index outputs

## Notes for review
- The benchmark harness is intentionally isolated under `extras/tests/scripts/`.
- Optional suffix-sort profiling is gated behind `STAR_PROFILE_SA_SORT=1`; normal runs do not emit those profiling details.
- The implementation keeps deterministic ordering for equal suffixes and was checked with byte comparisons on full-reference outputs.