### PR TITLE
Bound inserted-sequence suffix comparisons

### DIFF
--- a/extras/tests/scripts/testSuffixComparator.sh
+++ b/extras/tests/scripts/testSuffixComparator.sh
@@ -1,0 +1,15 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+repo_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../.." && pwd)"
+build_dir="$(mktemp -d)"
+trap 'rm -rf "${build_dir}"' EXIT
+
+"${CXX:-g++}" \
+    -std=c++11 -Wall -Wextra -fsanitize=address,undefined \
+    -I"${repo_dir}/source" \
+    "${repo_dir}/extras/tests/testSuffixComparator.cpp" \
+    "${repo_dir}/source/funCompareUintAndSuffixesMemcmp.cpp" \
+    -o "${build_dir}/testSuffixComparator"
+
+ASAN_OPTIONS=detect_leaks=0 "${build_dir}/testSuffixComparator"

--- a/extras/tests/testSuffixComparator.cpp
+++ b/extras/tests/testSuffixComparator.cpp
@@ -1,0 +1,52 @@
+#include "funCompareUintAndSuffixesMemcmp.h"
+
+#include <cstdint>
+#include <iostream>
+#include <limits>
+#include <vector>
+
+namespace {
+
+struct Entry {
+    uint64_t insertionPoint;
+    uint64_t suffix;
+};
+
+bool expectSign(const Entry &left, const Entry &right, int expectedSign, const char *label)
+{
+    int result=funCompareUintAndSuffixesMemcmp(&left, &right);
+    int resultSign=(result>0)-(result<0);
+    if (resultSign!=expectedSign)
+    {
+        std::cerr << label << ": expected sign " << expectedSign << ", observed " << resultSign << '\n';
+        return false;
+    };
+    return true;
+}
+
+}
+
+int main()
+{
+    std::vector<char> sequence={0,1,3,5, 0,1,2,5, 0,1,3,5, 2,2,2,5};
+    g_funCompareUintAndSuffixesMemcmp_G=sequence.data();
+    g_funCompareUintAndSuffixesMemcmp_N=sequence.size()-1;
+    g_funCompareUintAndSuffixesMemcmp_L=std::numeric_limits<uint64_t>::max();
+
+    Entry a={7,0};
+    Entry b={7,4};
+    Entry sameSuffix={7,8};
+    Entry earlierBucket={6,12};
+
+    bool ok=true;
+    ok &= expectSign(a, b, 1, "suffix order");
+    ok &= expectSign(b, a, -1, "reverse suffix order");
+    ok &= expectSign(a, sameSuffix, -1, "identical suffix tie break");
+    ok &= expectSign(a, a, 0, "self comparison");
+    ok &= expectSign(earlierBucket, a, -1, "insertion point order");
+
+    g_funCompareUintAndSuffixesMemcmp_L=2;
+    ok &= expectSign(a, b, -1, "finite prefix tie break");
+
+    return ok ? 0 : 1;
+}

--- a/source/funCompareUintAndSuffixesMemcmp.cpp
+++ b/source/funCompareUintAndSuffixesMemcmp.cpp
@@ -1,13 +1,14 @@
 #include "funCompareUintAndSuffixesMemcmp.h"
-#include <string.h> //for memcmp
+#include "IncludeDefine.h"
 
 char* g_funCompareUintAndSuffixesMemcmp_G;
+uint64_t g_funCompareUintAndSuffixesMemcmp_N;
 uint64_t g_funCompareUintAndSuffixesMemcmp_L;
 
 int funCompareUintAndSuffixesMemcmp ( const void *a, const void *b)
 {
-    uint64_t* va= ((uint64_t*) a);
-    uint64_t* vb= ((uint64_t*) b);
+    const uint64_t* va=static_cast<const uint64_t*>(a);
+    const uint64_t* vb=static_cast<const uint64_t*>(b);
 
     if (va[0]>vb[0])
     {
@@ -17,17 +18,34 @@ int funCompareUintAndSuffixesMemcmp ( const void *a, const void *b)
         return -1;
     } else
     {//compare suffixes
-//         char *p5=(char*) memchr(g_funCompareUintAndSuffixesMemcmp_G+va[1],5,g_funCompareUintAndSuffixesMemcmp_L); //first encounter of char=5
-//         char *p5=g_funCompareUintAndSuffixesMemcmp_G+va[1]+g_funCompareUintAndSuffixesMemcmp_L;
-        //compare suffixes but only until first char=5
-//         int comp=memcmp(g_funCompareUintAndSuffixesMemcmp_G+va[1],g_funCompareUintAndSuffixesMemcmp_G+vb[1],p5+1-(g_funCompareUintAndSuffixesMemcmp_G+va[1]));
-        int comp=memcmp(g_funCompareUintAndSuffixesMemcmp_G+va[1],g_funCompareUintAndSuffixesMemcmp_G+vb[1],g_funCompareUintAndSuffixesMemcmp_L);
-
-        if (comp==0)
+        const char* ga=g_funCompareUintAndSuffixesMemcmp_G+va[1];
+        const char* gb=g_funCompareUintAndSuffixesMemcmp_G+vb[1];
+        uint64_t compareLength=0;
+        if (va[1]<g_funCompareUintAndSuffixesMemcmp_N && vb[1]<g_funCompareUintAndSuffixesMemcmp_N)
         {
-            comp=va[1]>vb[1] ? 1 : -1;
+            compareLength=min(g_funCompareUintAndSuffixesMemcmp_L,
+                              min(g_funCompareUintAndSuffixesMemcmp_N-va[1]+1,
+                                  g_funCompareUintAndSuffixesMemcmp_N-vb[1]+1));
+            const char* sentinel=static_cast<const char*>(memchr(ga, GENOME_spacingChar, compareLength));
+            if (sentinel!=NULL)
+            {
+                compareLength=sentinel-ga+1;
+            };
         };
-//         int comp=va[1]>vb[1] ? 1 : -1;
-        return comp;
+
+        int comp=memcmp(ga, gb, compareLength);
+        if (comp!=0)
+        {
+            return comp;
+        };
+
+        if (va[1]>vb[1])
+        {
+            return 1;
+        } else if (va[1]<vb[1])
+        {
+            return -1;
+        };
+        return 0;
     };
 };

--- a/source/funCompareUintAndSuffixesMemcmp.h
+++ b/source/funCompareUintAndSuffixesMemcmp.h
@@ -4,6 +4,8 @@
 #include <stdint.h>
 
 extern char* g_funCompareUintAndSuffixesMemcmp_G;
+extern uint64_t g_funCompareUintAndSuffixesMemcmp_N;
+// Maximum number of bases to compare; UINT64_MAX means compare to the sentinel.
 extern uint64_t g_funCompareUintAndSuffixesMemcmp_L;
 int funCompareUintAndSuffixesMemcmp ( const void *a, const void *b);
 

--- a/source/insertSeqSA.cpp
+++ b/source/insertSeqSA.cpp
@@ -109,7 +109,8 @@ uint insertSeqSA(PackedArray & SA, PackedArray & SA1, PackedArray & SAi, char * 
     */
 
     g_funCompareUintAndSuffixesMemcmp_G=seq1[0];
-    g_funCompareUintAndSuffixesMemcmp_L=mapGen.pGe.gSuffixLengthMax/sizeof(uint64_t);
+    g_funCompareUintAndSuffixesMemcmp_N=2*nG1;
+    g_funCompareUintAndSuffixesMemcmp_L=mapGen.pGe.gSuffixLengthMax;
     qsort((void*) indArray, nInd, 2*sizeof(uint64_t), funCompareUintAndSuffixesMemcmp);
 
 //     qsort((void*) indArray, nInd, 2*sizeof(uint64), funCompareUint2);


### PR DESCRIPTION
## Summary

- Bound inserted-sequence suffix comparisons by the allocated sequence buffer.
- Interpret `genomeSuffixLengthMax` as a number of bases, consistently with genome generation.
- Stop comparisons at the genome spacing sentinel and return equality for self-comparisons.
- Add a focused ASan/UBSan regression test.

## Problem

Runtime sequence insertion (`alignReads --genomeFastaFiles ...`) passes the default unlimited suffix length into this comparator. On 2.7.11b, the caller divides that value by `sizeof(uint64_t)` and `memcmp` receives 2,305,843,009,213,693,951 bytes. ASan aborts in `funCompareUintAndSuffixesMemcmp`; the comparator also returns a nonzero result when given the same element twice.

## Validation

- `extras/tests/scripts/testSuffixComparator.sh` passes with ASan/UBSan; the same test against unmodified 2.7.11b fails in `memcmp`.
- A full STAR build succeeds.
- Runtime sequence insertion with the default suffix-length setting completes under ASan.
- Resulting SAM records are byte-identical to mapping against the equivalent prebuilt index.
