### PR TITLE
Avoid unaligned packed index accesses

### DIFF
--- a/extras/tests/scripts/testPackedArray.sh
+++ b/extras/tests/scripts/testPackedArray.sh
@@ -1,0 +1,15 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+repo_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../.." && pwd)"
+build_dir="$(mktemp -d)"
+trap 'rm -rf "${build_dir}"' EXIT
+
+"${CXX:-g++}" \
+    -std=c++11 -Wall -Wextra -fsanitize=address,undefined \
+    -I"${repo_dir}/source" \
+    "${repo_dir}/extras/tests/testPackedArray.cpp" \
+    "${repo_dir}/source/PackedArray.cpp" \
+    -o "${build_dir}/testPackedArray"
+
+ASAN_OPTIONS=detect_leaks=0 "${build_dir}/testPackedArray"

--- a/extras/tests/testPackedArray.cpp
+++ b/extras/tests/testPackedArray.cpp
@@ -1,0 +1,35 @@
+#include "PackedArray.h"
+
+#include <iostream>
+#include <vector>
+
+int main()
+{
+    const uint bits=13;
+    const uint count=257;
+    const uint mask=(1LLU<<bits)-1;
+
+    PackedArray packed;
+    packed.defineBits(bits, count);
+
+    std::vector<char> storage(packed.lengthByte+1, 0);
+    packed.pointArray(storage.data()+1);
+
+    for (uint ii=0; ii<count; ii++)
+    {
+        packed.writePacked(ii, (ii*7919+17)&mask);
+    };
+
+    for (uint ii=0; ii<count; ii++)
+    {
+        uint expected=(ii*7919+17)&mask;
+        if (packed[ii]!=expected)
+        {
+            std::cerr << "packed value mismatch at " << ii << ": expected "
+                      << expected << ", observed " << packed[ii] << '\n';
+            return 1;
+        };
+    };
+
+    return 0;
+}

--- a/source/Genome_genomeGenerate.cpp
+++ b/source/Genome_genomeGenerate.cpp
@@ -28,8 +28,8 @@ uint globalL;
 
 inline int funCompareSuffixes ( const void *a, const void *b){
 
-    uint *ga=(uint*)((globalG-7LLU)+(*((uint*)a)));
-    uint *gb=(uint*)((globalG-7LLU)+(*((uint*)b)));
+    const char *ga=(globalG-7LLU)+(*((uint*)a));
+    const char *gb=(globalG-7LLU)+(*((uint*)b));
 
     uint jj=0;
     int  ii=0;
@@ -37,8 +37,8 @@ inline int funCompareSuffixes ( const void *a, const void *b){
     uint8 *va1, *vb1;
 
     while (jj < globalL) {
-        va=*(ga-jj);
-        vb=*(gb-jj);
+        memcpy(&va, ga-jj*sizeof(uint), sizeof(va));
+        memcpy(&vb, gb-jj*sizeof(uint), sizeof(vb));
 
         #define has5(v) ((((v)^0x0505050505050505) - 0x0101010101010101) & ~((v)^0x0505050505050505) & 0x8080808080808080)
 

--- a/source/PackedArray.cpp
+++ b/source/PackedArray.cpp
@@ -20,8 +20,10 @@ void PackedArray::writePacked( uint jj, uint x) {
    uint S=b%8LLU;
 
    x = x << S;
-   uint* a1 = (uint*) (charArray+B);
-   *a1 = ( (*a1) & ~(bitRecMask<<S) ) | x;
+   uint a1;
+   memcpy(&a1, charArray+B, sizeof(a1));
+   a1 = (a1 & ~(bitRecMask<<S)) | x;
+   memcpy(charArray+B, &a1, sizeof(a1));
 };
 
 void PackedArray::pointArray(char* pointerCharIn) {

--- a/source/PackedArray.h
+++ b/source/PackedArray.h
@@ -26,7 +26,8 @@ inline uint PackedArray::operator [] (uint ii) {
    uint B=b/8;
    uint S=b%8;
 
-   uint a1 = *((uint*) (charArray+B));
+   uint a1;
+   memcpy(&a1, charArray+B, sizeof(a1));
    a1 = ((a1>>S)<<wordCompLength)>>wordCompLength;
    return a1;
 };

--- a/source/SuffixArrayFuns.cpp
+++ b/source/SuffixArrayFuns.cpp
@@ -359,7 +359,8 @@ uint funCalcSAiFromSA(char* gSeq, PackedArray& gSA, Genome &mapGen, uint iSA, in
     register uint saind=0;
     if (dirG)
     {
-        register uint128 g1=*( (uint128*) (gSeq+SAstr) );
+        register uint128 g1;
+        memcpy(&g1, gSeq+SAstr, sizeof(g1));
         for (int ii=0; ii<L; ii++)
         {
             register char g2=(char) g1;
@@ -376,7 +377,8 @@ uint funCalcSAiFromSA(char* gSeq, PackedArray& gSA, Genome &mapGen, uint iSA, in
         return saind;
     } else
     {
-        register uint128 g1=*( (uint128*) (gSeq+mapGen.nGenome-SAstr-16) );
+        register uint128 g1;
+        memcpy(&g1, gSeq+mapGen.nGenome-SAstr-16, sizeof(g1));
         for (int ii=0; ii<L; ii++)
         {
             register char g2=(char) (g1>>(8*(15-ii)));


### PR DESCRIPTION
## Summary

- Replace unaligned typed loads and stores in `PackedArray` with fixed-size `memcpy` operations.
- Apply the same treatment to packed suffix loads used during genome generation and suffix-array search.
- Add an odd-address ASan/UBSan regression test.

## Problem

STAR intentionally packs arrays at byte-granular offsets, but several accessors cast those addresses to `uint64_t*` or `uint128*` and dereference them. These operations are undefined on unaligned addresses and are reported during both index generation and mapping by UBSan.

## Validation

- `extras/tests/scripts/testPackedArray.sh` passes; its odd-address case reports a misaligned access against unmodified 2.7.11b.
- A full ASan/UBSan build succeeds.
- Tiny annotated `genomeGenerate` completes with `UBSAN_OPTIONS=halt_on_error=1`.
- Fourteen core genome and annotation artifacts, including `Genome`, `SA`, `SAindex`, chromosome metadata, gene/transcript/exon tables, and SJDB files, are byte-identical to unmodified 2.7.11b.
