### PR TITLE
Initialize optional transcriptome state

### DIFF
--- a/extras/tests/scripts/testTranscriptInitialization.sh
+++ b/extras/tests/scripts/testTranscriptInitialization.sh
@@ -1,0 +1,16 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+repo_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../.." && pwd)"
+build_dir="$(mktemp -d)"
+trap 'rm -rf "${build_dir}"' EXIT
+
+"${CXX:-g++}" \
+    -std=c++11 -Wall -Wextra -fsanitize=address,undefined \
+    -I"${repo_dir}/source" \
+    "${repo_dir}/extras/tests/testTranscriptInitialization.cpp" \
+    "${repo_dir}/source/Transcript.cpp" \
+    -o "${build_dir}/testTranscriptInitialization"
+
+ASAN_OPTIONS=detect_leaks=0 UBSAN_OPTIONS=halt_on_error=1 \
+    "${build_dir}/testTranscriptInitialization"

--- a/extras/tests/testTranscriptInitialization.cpp
+++ b/extras/tests/testTranscriptInitialization.cpp
@@ -1,0 +1,22 @@
+#include "Transcript.h"
+
+#include <cstring>
+#include <iostream>
+#include <new>
+
+int main()
+{
+    alignas(Transcript) unsigned char storage[sizeof(Transcript)];
+    memset(storage, 0xbe, sizeof(storage));
+
+    Transcript *transcript=new (storage) Transcript;
+    bool initialized=!transcript->sjYes && !transcript->primaryFlag;
+    transcript->~Transcript();
+
+    if (!initialized)
+    {
+        std::cerr << "Transcript boolean state was not initialized\n";
+        return 1;
+    };
+    return 0;
+}

--- a/source/STAR.cpp
+++ b/source/STAR.cpp
@@ -124,11 +124,14 @@ int main(int argInN, char *argIn[])
         exit(1);
     };
 
-    // transcripome placeholder
-    Transcriptome *transcriptomeMain = NULL;
-
     // this will execute --runMode soloCellFiltering and exit
-    Solo soloCellFilter(P, *transcriptomeMain);
+    if (P.runMode == "soloCellFiltering")
+    {
+        Transcriptome transcriptomeCellFilter(P);
+        Solo soloCellFilter(P, transcriptomeCellFilter);
+    };
+
+    Transcriptome *transcriptomeMain = NULL;
 
     ////////////////////////////////////////////////////////////////////////
     ///////////////////////////////// Genome
@@ -169,10 +172,8 @@ int main(int argInN, char *argIn[])
     //////////////////////////////////// 2-pass 1st pass
     twoPassRunPass1(P, genomeMain, transcriptomeMain, sjdbLoci);
 
-    if (P.quant.yes)
-    { // load transcriptome
-        transcriptomeMain = new Transcriptome(P);
-    };
+    // The constructor is a no-op when transcriptome data are not needed.
+    transcriptomeMain = new Transcriptome(P);
 
     // initialize Stats
     g_statsAll.resetN();
@@ -252,7 +253,7 @@ int main(int argInN, char *argIn[])
         outputSJ(RAchunk, P);
 
     // solo counts
-    Solo soloMain(RAchunk, P, *RAchunk[0]->chunkTr);
+    Solo soloMain(RAchunk, P, *transcriptomeMain);
     soloMain.processAndOutput();
 
     if (P.quant.geCount.yes)

--- a/source/Transcript.cpp
+++ b/source/Transcript.cpp
@@ -13,6 +13,7 @@ void Transcript::reset() {
 //         polyXnMM[ii]=0;
 //     };
     primaryFlag=false;
+    sjYes=false;
 
     rStart=0; roStart=0; rLength=0; gStart=0; gLength=0; //read and genomic coordinates
 


### PR DESCRIPTION
## Summary

- Construct a valid `Transcriptome` object before APIs requiring a reference receive it.
- Keep `soloCellFiltering` on its early-exit path with a real local transcriptome object.
- Reuse the main transcriptome object for final Solo processing.
- Initialize `Transcript::sjYes` in `reset()`.
- Add a focused initialization regression test.

## Problem

Ordinary mapping currently forms `Transcriptome&` references from a null pointer in `STAR.cpp`, even when downstream code does not inspect transcriptome data. UBSan reports those reference bindings. Separately, `Transcript::sjYes` is left uninitialized and can be read during alignment; UBSan reports an invalid `bool` value.

The `Transcriptome` constructor already returns immediately when transcriptome quantification is not requested, so constructing a valid no-op object preserves the existing fast path.

## Validation

- `extras/tests/scripts/testTranscriptInitialization.sh` passes; the same placement-new test against unmodified 2.7.11b reports an invalid `bool` load.
- A full ASan/UBSan build succeeds.
- Ordinary mapping no longer reports null-reference or invalid-`bool` diagnostics.
- SAM records are byte-identical to unmodified 2.7.11b.
