### PR TITLE
Align in-memory splice-junction records

### DIFF
--- a/extras/tests/scripts/testJunctionAlignment.sh
+++ b/extras/tests/scripts/testJunctionAlignment.sh
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+repo_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../.." && pwd)"
+build_dir="$(mktemp -d)"
+trap 'rm -rf "${build_dir}"' EXIT
+
+"${CXX:-g++}" \
+    -std=c++11 -Wall -Wextra \
+    -I"${repo_dir}/source" \
+    "${repo_dir}/extras/tests/testJunctionAlignment.cpp" \
+    -o "${build_dir}/testJunctionAlignment"
+
+"${build_dir}/testJunctionAlignment"

--- a/extras/tests/testJunctionAlignment.cpp
+++ b/extras/tests/testJunctionAlignment.cpp
@@ -1,0 +1,22 @@
+#include "OutSJ.h"
+
+#include <cstdint>
+#include <type_traits>
+#include <utility>
+
+using JunctionStorage=decltype(std::declval<OutSJ>().dataVec);
+
+static_assert(std::is_same<JunctionStorage::value_type, uint64>::value,
+              "junction storage must provide uint64 alignment");
+static_assert(Junction::startP % alignof(uint) == 0, "unaligned junction start");
+static_assert(Junction::gapP % alignof(uint32) == 0, "unaligned junction gap");
+static_assert(Junction::countUniqueP % alignof(uint32) == 0, "unaligned unique count");
+static_assert(Junction::countMultipleP % alignof(uint32) == 0, "unaligned multiple count");
+static_assert(Junction::overhangLeftP % alignof(uint16) == 0, "unaligned left overhang");
+static_assert(Junction::overhangRightP % alignof(uint16) == 0, "unaligned right overhang");
+static_assert(Junction::dataSize % alignof(uint64) == 0, "unaligned junction records");
+
+int main()
+{
+    return 0;
+}

--- a/source/OutSJ.cpp
+++ b/source/OutSJ.cpp
@@ -5,8 +5,8 @@ OutSJ::OutSJ (uint nSJmax, Parameters &Pin, Genome &genomeIn) : oneSJ(genomeIn),
 
     //data = new char [oneSJ.dataSize*nSJmax]; //allocate big array of SJ loci and properties
     Nstore = nSJmax;
-    dataVec.resize(oneSJ.dataSize*Nstore);
-    data = dataVec.data();
+    dataVec.resize(oneSJ.dataSize*Nstore/sizeof(dataVec[0]));
+    data = reinterpret_cast<char*>(dataVec.data());
     memset(data,0,oneSJ.dataSize*Nstore);
     N=0;//initialize the counter
 };
@@ -61,8 +61,8 @@ void OutSJ::collapseSJ() {//collapse junctions. Simple version now: re-sort ever
 
 void OutSJ::dataSizeIncrease() {
     Nstore *= 2;
-    dataVec.resize(oneSJ.dataSize*Nstore);
-    data = dataVec.data();
+    dataVec.resize(oneSJ.dataSize*Nstore/sizeof(dataVec[0]));
+    data = reinterpret_cast<char*>(dataVec.data());
 };
 
 Junction::Junction(Genome &genOut) : genOut(genOut) {

--- a/source/OutSJ.h
+++ b/source/OutSJ.h
@@ -11,7 +11,7 @@ public:
     const static uint strandP=gapP+sizeof(uint32);
     const static uint motifP=strandP+sizeof(char);
     const static uint annotP=motifP+sizeof(char);
-    const static uint countUniqueP=annotP+sizeof(char);
+    const static uint countUniqueP=((annotP+sizeof(char)+alignof(uint32)-1)/alignof(uint32))*alignof(uint32);
     const static uint countMultipleP=countUniqueP+sizeof(uint32);
     const static uint overhangLeftP=countMultipleP+sizeof(uint32);
     const static uint overhangRightP=overhangLeftP+sizeof(uint16);
@@ -22,7 +22,7 @@ public:
     uint32 *countUnique, *countMultiple;
     uint16 *overhangLeft, *overhangRight;
 
-    const static uint dataSize=overhangRightP+sizeof(uint16);
+    const static uint dataSize=((overhangRightP+sizeof(uint16)+alignof(uint64)-1)/alignof(uint64))*alignof(uint64);
 
     Junction(Genome &genomeIn);
     void junctionPointer(char* sjPoint, uint isj);
@@ -38,7 +38,7 @@ class OutSJ {
 public:
     //all junctions
     char* data; //sj array[Njunctions][dataSize]
-    vector<char> dataVec;
+    vector<uint64> dataVec;
     uint64 N, Nstore; //N=number of junctions stored; Nstore=storage size
     Junction oneSJ;
 
@@ -56,4 +56,3 @@ private:
 int compareSJ(const void* i1, const void* i2); //external functions
 
 #endif
-


### PR DESCRIPTION
## Summary

- Align every typed field in the in-memory `Junction` record.
- Pad each record from 23 to 24 bytes so records remain aligned in arrays.
- Back the byte-addressed record buffer with `vector<uint64>` to guarantee suitable base alignment.
- Add compile-time alignment regression checks.

## Problem

The current 23-byte record places 32-bit counters at offsets 11 and 15 and 16-bit overhangs at offsets 19 and 21. `Junction` then exposes typed pointers to those fields and dereferences them. UBSan reports these stores during normal spliced-read mapping, beginning in `ReadAlign_outputTranscriptSJ.cpp`.

This is an internal runtime buffer change only; no genome-index or output-file format changes.

## Validation

- `extras/tests/scripts/testJunctionAlignment.sh` passes; its static assertions fail against unmodified 2.7.11b on the storage type, field offsets, and record stride.
- A full ASan/UBSan build succeeds.
- Spliced-read mapping no longer reports junction-record alignment errors.
- SAM records, `SJ.out.tab`, and `ReadsPerGene.out.tab` are byte-identical to unmodified 2.7.11b.
